### PR TITLE
YouthPlayerOverviewTableModel.initData remove calcTrainingDevelopment

### DIFF
--- a/src/main/java/module/youth/YouthPlayerOverviewTableModel.java
+++ b/src/main/java/module/youth/YouthPlayerOverviewTableModel.java
@@ -110,7 +110,6 @@ public class YouthPlayerOverviewTableModel extends HOTableModel {
         m_clData = new Object[youthplayers.size()][columns.length];
         int playernum = 0;
         for (var player : youthplayers) {
-            player.calcTrainingDevelopment();
             int columnnum = 0;
             for (var col : displayedColumns) {
                 m_clData[playernum][columnnum] = ((YouthPlayerColumn) col).getTableEntry(player, null);


### PR DESCRIPTION
1. changes proposed in this pull request:
 
 remove unnecessary call of calcTrainingDevelopment
 
 
2. changelog and release_notes ...

 - [ ] have been updated
 - [x] do not require update


3. [Optional] suggested person to review this PR @___
