### PR TITLE
Change order of Gradle tasks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,8 +208,11 @@ distributions {
 }
 
 install4j {
-    if (install4jHomeDir != null && install4jHomeDir != "") installDir = file(install4jHomeDir)
-    else installDir = file(System.getenv('INSTALL4J_HOME'))
+    if (install4jHomeDir != null && install4jHomeDir != "") {
+        installDir = file(install4jHomeDir)
+    } else if (System.getenv('INSTALL4J_HOME')) {
+        installDir = file(System.getenv('INSTALL4J_HOME')) as File
+    }
     disableSigning = true
     license = System.getenv('INSTALL4J_LICENSE')
 }
@@ -283,7 +286,7 @@ task media(type: com.install4j.gradle.Install4jTask) {
     variables = [HO_version: project.version, projectDir: projectDir, versionType: versionType]
 }
 
-task preparingBuild(dependsOn: clean) {
+task preparingBuild {
     group 'sub tasks'
     doLast {
         if (releaseArtefacts) {
@@ -484,6 +487,8 @@ markdownToHtml.dependsOn pushmd
 poeditorPull.dependsOn markdownToHtml
 createLanguageFileList.dependsOn poeditorPull
 processResources.dependsOn createLanguageFileList
+compileJava.dependsOn(clean)
 compileJava.dependsOn processResources
+
 
 // endregion ======================================================================================================================


### PR DESCRIPTION
The `clean` task is called after `compileKotlin`, and before `compileJava`, causing the output of the Kotlin compilation to be wiped, and therefore not made available to the Java compilation.

This commit re-orders tasks to get `clean` done before the other tasks for `compileJava`.  Hopefully, this should solve the build issues encountered with Kotlin in the Github workflow...

This commit also verifies the presence of the `INSTALL4J_HOME` env var to avoid compile issue when checking out the project the first time.

1. changes proposed in this pull request:

cf. above

2. `src/main/resources/release_notes.md` ...

 - [ ] has been updated
 - [x] does not require update


3. [Optional] suggested person to review this PR @wsbrenk 
