### PR TITLE
Correct operator, and typo in column name in SQL query.

### DIFF
--- a/src/main/java/core/db/TransferTable.java
+++ b/src/main/java/core/db/TransferTable.java
@@ -203,7 +203,7 @@ public class TransferTable extends AbstractTable {
         return load(PlayerTransfer.class, this.adapter.executePreparedQuery(statement, teamId));
     }
 
-    DBManager.PreparedStatementBuilder getSumTransferCommissionsStatementBuilder = new DBManager.PreparedStatementBuilder("SELECT SUM(motherclubfee+previousclubcommission) FROM " + TABLENAME + " WHERE date=>? AND dete<?");
+    DBManager.PreparedStatementBuilder getSumTransferCommissionsStatementBuilder = new DBManager.PreparedStatementBuilder("SELECT SUM(motherclubfee+previousclubcommission) FROM " + TABLENAME + " WHERE date>=? AND date<?");
 
     public int getSumTransferCommissions(HODateTime startOfWeek) {
         var from = startOfWeek.toDbTimestamp();

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -7,6 +7,7 @@
 ## [Detailed Changelog](https://github.com/ho-dev/HattrickOrganizer/issues?q=milestone%3A8.0)
 
 ### Database
+* fix `unexpected token` issue with Transfer table query (#1965)
 
 ### Squad
 * fix length of owner notes in players' database table (#1816)


### PR DESCRIPTION
Fix #1965

1. changes proposed in this pull request:

   - fixes issue #1965 



2. `src/main/resources/release_notes.md` ...

 - [x] has been updated
 - [ ] does not require update


3. [Optional] suggested person to review this PR @wsbrenk 
