### PR TITLE
fix SkillChange.getHtSeason

### DIFF
--- a/src/main/java/core/model/player/SkillChange.java
+++ b/src/main/java/core/model/player/SkillChange.java
@@ -37,7 +37,7 @@ public class SkillChange {
     }
 
     public int getHtSeason() {
-        return date.toHTWeek().season;
+        return date.toLocaleHTWeek().season;
     }
 
     public int getHtWeek() {


### PR DESCRIPTION
1. changes proposed in this pull request:

   - fixes error in training prediction when league's locale season differs from swedish league


2. `src/main/resources/release_notes.md` ...

 - [ ] has been updated
 - [x] does not require update


3. [Optional] suggested person to review this PR @___
