### PR TITLE
Override version in jar manifest in `createVersion`.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,9 +168,11 @@ poeditor {
 jar {
     archiveFileName = "HO.jar"
     manifest {
-        attributes 'Manifest-Version': 1.0, 'Implementation-Title': 'HO', 'Implementation-Version': project.version,
-                   'Main-Class': 'core.HOLauncher',
-                    "Class-Path": configurations.runtimeClasspath.collect { it.getName() }.join(' ')
+        attributes 'Manifest-Version': 1.0,
+                'Implementation-Title': 'HO',
+                'Implementation-Version': project.version,
+                'Main-Class': 'core.HOLauncher',
+                "Class-Path": configurations.runtimeClasspath.collect { it.getName() }.join(' ')
     }
     exclude "/*.jar", "/*.ico", "/*.png", "/*.md", "/*.html"
 }
@@ -225,9 +227,13 @@ tasks.register("createVersion") {
         def buildNumber = System.getenv("RUN_NUMBER") ?: "0"
 
         project.version = "${major}.${minor}.${buildNumber}.${developmentStage}".toString()
+        // Version in jar extension is set eagerly, override after computing version.
+        jar.manifest {
+            attributes('Implementation-Version': project.version)
+        }
 
         versionProps['buildNumber'] = buildNumber
-        versionProps['version'] = project.version
+        versionProps['version'] = project.version.toString()
         versionProps['shortVersion'] = "${major}.${minor}".toString()
         versionProps['tag'] = ['dev', 'beta', 'tag_stable'].get(developmentStage)
         versionProps['branch'] = currentBranch

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -54,6 +54,7 @@
 * Add Kotlin support to codebase
 * Reset progress bar when action is finished (#1955)
 * Upgrade Gradle to version 8.5
+* Fix issue with startup post-installation (#2002)
 
 ## Translations
 


### PR DESCRIPTION
Jar extension sets the version in an eager fashion, thus not taking into account the version as it is computed by `createVersion`.  This commit overrides the jar manifest version once it has been defined.

1. changes proposed in this pull request:

   - fixes issue #2002 


2. `src/main/resources/release_notes.md` ...

 - [x] has been updated
 - [ ] does not require update


3. [Optional] suggested person to review this PR @wsbrenk 
