### PR TITLE
#1471 enable standard popup menus in oauth dialog's text fields

### DIFF
--- a/src/main/java/core/net/login/OAuthDialog.java
+++ b/src/main/java/core/net/login/OAuthDialog.java
@@ -10,26 +10,16 @@ import core.model.UserParameter;
 import core.util.BrowserLauncher;
 import core.util.HOLogger;
 import core.util.Helper;
-import java.awt.Dimension;
-import java.awt.FlowLayout;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import javax.swing.JTextField;
-
-//import org.scribe.model.Token;
-//import com.github.scribejava.core;
-//import org.scribe.oauth.OAuthService;
 
 public class OAuthDialog extends JDialog {
 
@@ -39,8 +29,8 @@ public class OAuthDialog extends JDialog {
 	private final JButton m_jbOK = new JButton();
 	private final JButton m_jbBrowse = new JButton();
 	private final JButton m_jbCancel = new JButton();
-	private final JTextField m_jtfAuthString = new JTextField();
-	private final JTextField m_jtfAuthURL = new JTextField();
+	private final TextField m_jtfAuthString = new TextField();
+	private final TextField m_jtfAuthURL = new TextField();
 	private String m_sUserURL;
 	private boolean m_bUserCancel = false;
 	private boolean m_bFirstTry = true;

--- a/src/main/java/core/net/login/OAuthDialog.java
+++ b/src/main/java/core/net/login/OAuthDialog.java
@@ -15,6 +15,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.Serial;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
@@ -23,6 +24,7 @@ import javax.swing.JPanel;
 
 public class OAuthDialog extends JDialog {
 
+	@Serial
 	private static final long serialVersionUID = 1798304851624958795L;
 
 	private final HOMainFrame m_clMainFrame;
@@ -37,7 +39,7 @@ public class OAuthDialog extends JDialog {
 	private final OAuth10aService m_service;
 	private OAuth1AccessToken m_AccessToken;
 	private OAuth1RequestToken m_RequestToken;
-	private String scopes = "";
+	private String scopes;
 
 	public OAuthDialog(HOMainFrame mainFrame, OAuth10aService service, String scope) {
 		super(mainFrame, HOVerwaltung.instance().getLanguageString(
@@ -107,7 +109,7 @@ public class OAuthDialog extends JDialog {
 		ActionListener actionListener = new ActionListener() {
 
 			@Override
-			public final void actionPerformed(ActionEvent actionEvent) {
+			public void actionPerformed(ActionEvent actionEvent) {
 				if (actionEvent.getSource().equals(m_jbOK)) {
 					doAuthorize();
 				} else if (actionEvent.getSource().equals(m_jbBrowse)) {

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -70,6 +70,7 @@
 * Fix issue with startup post-installation (#2002)
 * Fix NPE when saving preferences on un-managed HO install (#1992)
   HO now downloads the update in the browser when HO install is un-managed.
+* Enable standard custom popup menu in oauth dialog's text fields (#1471)
 
 ## Translations
 


### PR DESCRIPTION
1. changes proposed in this pull request:

   - fixes issue #1471
   - if not fixing an existing issue, comments explaining the purpose of the PR should be provided)


2. `src/main/resources/release_notes.md` ...

 - [x] has been updated
 - [ ] does not require update


3. [Optional] suggested person to review this PR @tychobrailleur : Do you think it is a good idea replacing JTextfields with awt.Textfield?
