### PR TITLE
Create `stable` tag when `tag_stable` is created. (#2081)

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -72,7 +72,7 @@ jobs:
           --url https://api.github.com/repos/ho-dev/HattrickOrganizer/releases/${{ steps.create_release.outputs.id }} \
           --data '{ "draft": false }'
       - name: If not dev-release delete previous short version tag
-        if: ${{ steps.read_version_properties.outputs.tag != 'dev'}}
+        if: ${{ steps.read_version_properties.outputs.tag != 'dev' }}
         uses: ClementTsang/delete-tag-and-release@v0.3.1
         with:
           delete_release: true
@@ -80,7 +80,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       - name: If not dev-release create a Release with short version tag
-        if: ${{ steps.read_version_properties.outputs.tag != 'dev'}}
+        if: ${{ steps.read_version_properties.outputs.tag != 'dev' }}
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
@@ -91,4 +91,10 @@ jobs:
           tag_name: ${{ steps.read_version_properties.outputs.shortVersion }}
           body_path: docs/md/release_notes.md
           target_commitish: ${{ steps.read_version_properties.outputs.branch }}
-          prerelease: ${{ steps.read_version_properties.outputs.tag != 'tag_stable'}}
+          prerelease: ${{ steps.read_version_properties.outputs.tag != 'tag_stable' }}
+      - name: If 'tag_stable' release, also create 'stable' tag
+        if: ${{ steps.read_version_properties.outputs.tag == 'tag_stable' }}
+        uses: rickstaa/action-create-tag@v1.7.2
+        with:
+          tag: stable
+          tag_exists_error: false

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -88,6 +88,7 @@
 * Enable standard custom popup menu in oauth dialog's text fields (#1471)
 * Move previous series download checkbox to the check box tree of download dialog (#1434)
 * Add 6 new countries to international flag module (#2063)
+* Fix missing `stable` tag when creating `tag_stable` release (#2081)
 
 ## Translations
 


### PR DESCRIPTION
1. changes proposed in this pull request:

   - fixes issue #2081 , this cherry-picks change in 8d8365b


2. `src/main/resources/release_notes.md` ...

 - [x] has been updated
 - [ ] does not require update


3. [Optional] suggested person to review this PR @wsbrenk 
