### PR TITLE
fix: property 'window.about.text': adding homogeneous line break afte…

### DIFF
--- a/src/main/resources/sprache/Catalan.properties
+++ b/src/main/resources/sprache/Catalan.properties
@@ -1414,7 +1414,7 @@ ls.menu.help.about = Quant a
 # About window from Top menu Help->About:  Title
 window.about.title = Crèdits
 # About window from Top menu Help->About:  Text
-window.about.text = El desenvolupament va començar el 2003 per part de Thomas Werth & Volker Fischer. Des de 2006, aquest projecte és de codi obert i desenvolupat per diferents desenvolupadors.
+window.about.text = El desenvolupament va començar el 2003 per part de Thomas Werth & Volker Fischer.\nDes de 2006, aquest projecte és de codi obert i desenvolupat per diferents desenvolupadors.
 # About window from Top menu Help->About:  Text
 window.about.licence = Llicència
 ls.button.update.linux.pkg.warning = Estàs executant HO a través d'un paquet instal·lat al teu sistema. Si actualitzes HO a través d'aquesta interfície, el teu sistema no serà informat de l'actualització del programa. \nPer tant, existirà una discrepància entre la versió de HO informada pel teu sistema i la que efectivament està instal·lada i en ús (en el cas que calgui una nova dependència de Java, el teu sistema no la instal·larà automàticament).\nNo obstant, això no hauria de tenir conseqüències i en cas de problemes sempre tindràs la possibilitat d'instal·lar/actualitzar HO a sobre de la instal·lació existent usant un paquet.\nEncara vols continuar?

--- a/src/main/resources/sprache/Czech.properties
+++ b/src/main/resources/sprache/Czech.properties
@@ -1449,7 +1449,7 @@ ls.menu.help.about = O projektu
 # About window from Top menu Help->About:  Title
 window.about.title = Credits
 # About window from Top menu Help->About:  Text
-window.about.text = 2003 Thomas Werth a Volker Fischer začali s vývojem. Od roku 2006 je tento projekt open source a je vyvíjen různými vývojáři.
+window.about.text = 2003 Thomas Werth a Volker Fischer začali s vývojem.\nOd roku 2006 je tento projekt open source a je vyvíjen různými vývojáři.
 # About window from Top menu Help->About:  Text
 window.about.licence = Licence
 ls.button.update.linux.pkg.warning = HO jste nainstalovali pomocí instalačního balíčku ve Vašem systému\nPokud takto updateujete HO, Váš systém nebude informován o nových HO updatech.\nMůže se tedy stát, že verze, kterou HO bude ukazovat, nebude odpovídat reálně nainstalované a používané verzi (pokud bude potřeba povýšit Javu, Váš systém to neudělá sám).\nNicméně program bude fungovat a v případě problému máte vždy možnost nainstalovat/updateovat HO balíčkovým instalátorem.\nChcete přesto pokračovat?

--- a/src/main/resources/sprache/Danish.properties
+++ b/src/main/resources/sprache/Danish.properties
@@ -1451,7 +1451,7 @@ ls.menu.help.about = Om
 # About window from Top menu Help->About:  Title
 window.about.title = Credits
 # About window from Top menu Help->About:  Text
-window.about.text = I 2013 startede programudviklingen af Thomas Werth og Volker Fischer. Siden 2016 har HO fungeret som opensource projekt og videreudviklet med skiftende programmører.
+window.about.text = I 2003 startede programudviklingen af Thomas Werth og Volker Fischer.\nSiden 2006 har HO fungeret som opensource projekt og videreudviklet med skiftende programmører.
 # About window from Top menu Help->About:  Text
 window.about.licence = Licens
 ls.button.update.linux.pkg.warning = Du kører HO via en pakkeinstallation på din maskine. Hvis du opdaterer HO via dette interface, bliver dit system ikke informeret omkring programopdateringen. Derfor vil der være en uoverensstemmelse mellem HO versionerne der hhv. er installeret og i brug (i tilfælde af en Java opdatering er påkrævet, vil din maskine ikke automatisk installere denne).\nDet bør dog som udgangspunkt ikke have nogle konsekvenser – men i tilfælde af problemer vil du altid have mulighed for at opdatere din HO via en ny pakkeinstallation.\nVil du stadig fortsætte

--- a/src/main/resources/sprache/Deutsch.properties
+++ b/src/main/resources/sprache/Deutsch.properties
@@ -1438,7 +1438,7 @@ ls.menu.help.about = Über
 # About window from Top menu Help->About:  Title
 window.about.title = Credits
 # About window from Top menu Help->About:  Text
-window.about.text = 2003 begann die Entwicklung durch Thomas Werth & Volker Fischer. Seit 2006 ist dies ein Open Source Projekt und wird von wechselnden Entwicklern weiter entwickelt.
+window.about.text = 2003 begann die Entwicklung durch Thomas Werth & Volker Fischer.\nSeit 2006 ist dies ein Open Source Projekt und wird von wechselnden Entwicklern weiter entwickelt.
 # About window from Top menu Help->About:  Text
 window.about.licence = Lizenz
 ls.button.update.linux.pkg.warning = Der HO läuft über ein Paket, das in Deinem System installiert wurde. Falls Du den HO über diese Funktion updatest, wird Dein System hierüber nicht informiert. Deshalb wird es eine Diskrepanz zwischen der Version des HO geben, die Dein System angibt und der Version, die effektiv installiert und in Benutzung ist (falls für das Update eine neue Java Version benötigt wird, wird Dein System das Update nicht automatisch ausführen). Das sollte aber keine besonderen Folgen haben. Im Fall eines Problems bleibt Dir immer die Möglichkeit, den HO statt über diese Funktion über ein neues Paket herunterzuladen, mit dem Du die bisherige Version überschreibst.

--- a/src/main/resources/sprache/Greeklish.properties
+++ b/src/main/resources/sprache/Greeklish.properties
@@ -1428,7 +1428,7 @@ ls.menu.help.about = Sxetika
 # About window from Top menu Help->About:  Title
 window.about.title = Efxaristies
 # About window from Top menu Help->About:  Text
-window.about.text = H anaptyxh toy programmatos arxise to 2003 apo toys Thomas Werth & Volker Fischer. Apo to 2006 to project einai open source kai anaptyssete apo diaforetikoys programmatistes.
+window.about.text = H anaptyxh toy programmatos arxise to 2003 apo toys Thomas Werth & Volker Fischer.\nApo to 2006 to project einai open source kai anaptyssete apo diaforetikoys programmatistes.
 # About window from Top menu Help->About:  Text
 window.about.licence = Adeia
 ls.button.update.linux.pkg.warning = Trexete to HO apo ena paketo poy egkatastathike sto systhma sas. An kanete update me ton idio tropo, to systhma sas de tha plhroforhthei thn allagh.\nEtsi, tha yparxei diafora metaxy ths ekdoshs toy systhmatos kai ths pragmatikhs (se periptwsh poy xreazetai neo Java, to systhma sas den tha to egkatasthsei aytomata).\nParola ayta den tha yparxoyn synepeies kai an yparxei kapoio problhma mporeite na kanete egkatastash/enhmerwsh panw apo to yparxwn programma.\nThelete na synexisete

--- a/src/main/resources/sprache/Hrvatski(Croatian).properties
+++ b/src/main/resources/sprache/Hrvatski(Croatian).properties
@@ -1428,7 +1428,7 @@ ls.menu.help.about = About
 # About window from Top menu Help->About:  Title
 window.about.title = Credits
 # About window from Top menu Help->About:  Text
-window.about.text = Thomas Werth & Volker Fischer su 2003 započeli razvoj. Od 2006 ovaj projekt je otvorenog koda (open source) i razvija se od strane developera koji se često izmijenjuju. 
+window.about.text = Thomas Werth & Volker Fischer su 2003 započeli razvoj.\nOd 2006 ovaj projekt je otvorenog koda (open source) i razvija se od strane developera koji se često izmijenjuju. 
 # About window from Top menu Help->About:  Text
 window.about.licence = Licenca
 ls.button.update.linux.pkg.warning = You are running HO via a package installed in your system.\nIf you update HO via this interface, your system will not be informed of the program update.\nHence, a discrepancy will exists between the version of HO reported by your system and\nthe one effectively installed and in use (in case new Java dependency is required,\nyour system won’t install them automatically).\nThis should however have no consequences and in case of problem\nyou will always have the possibility to install/update HO over your existing install using a package.\nDo you still want to continue

--- a/src/main/resources/sprache/Polish.properties
+++ b/src/main/resources/sprache/Polish.properties
@@ -1415,7 +1415,7 @@ ls.menu.help.about = O programie
 # About window from Top menu Help->About:  Title
 window.about.title = Twórcy
 # About window from Top menu Help->About:  Text
-window.about.text = W 2003 pracę nad programem rozpoczęli Thomas Werth i Volker Fischer. W 2006 projekt stał się open source i od tego czasu był rozwijany przez wielu programistów.
+window.about.text = W 2003 pracę nad programem rozpoczęli Thomas Werth i Volker Fischer.\nW 2006 projekt stał się open source i od tego czasu był rozwijany przez wielu programistów.
 # About window from Top menu Help->About:  Text
 window.about.licence = Licencja
 ls.button.update.linux.pkg.warning = Używasz HO zainstalowanego przy użyciu menedżera pakietów.\nJeżeli użyjesz tej funkcji do aktualizacji Twój system nie zostanie powiadomiony.\nW związku z tym dojdzie do nieścisłości pomiędzy wersją faktycznie zainstalowaną a tą która zna (może to wpłynąć na automatyczne instalowanie zależności).\nZwykle nie powinno to pociągać za sobą konsekwencji. W razie problemów zawsze możesz nadpisać instalacje na tej instalacji używając menedżera pakietów.\nCzy nadal chcesz kontynuować?

--- a/src/main/resources/sprache/Slovak.properties
+++ b/src/main/resources/sprache/Slovak.properties
@@ -1449,7 +1449,7 @@ ls.menu.help.about = O
 # About window from Top menu Help->About:  Title
 window.about.title = Kredity
 # About window from Top menu Help->About:  Text
-window.about.text = Vyvoj zacal v 2003 Thomasom Werthom & Volkerom Fischerom. Od 2006 je projekt otvoreny a vyvyijany zmenami vyvojarov.
+window.about.text = Vyvoj zacal v 2003 Thomasom Werthom & Volkerom Fischerom.\nOd 2006 je projekt otvoreny a vyvyijany zmenami vyvojarov.
 # About window from Top menu Help->About:  Text
 window.about.licence = Licencia
 ls.button.update.linux.pkg.warning = Mas spuste HO skrz balik instalovany v tvojom systeme. Ak budes aktualizovat HO skrz toto rozhranie, tvoj system ta nebude informovat o aktualizaciach programu. \nTym padom bude existovat nesulad medzi verziou HO vykazovanou v tvojom systeme a tou skutocne nainstalovanou a pouzivanou (pokial nie je pozadovane nove Java rozhranie, vtedy tvoj system nebude automaticky aktualizovany).\nToto by vsak nemalo mat ziadne nasledky a v pripade problemu vzdy budes mat moznost instalovat/aktualizovat HO cez tvoju existujuci instalaciu pouzitim balicka. \nChces pokracovat

--- a/src/main/resources/sprache/Spanish.properties
+++ b/src/main/resources/sprache/Spanish.properties
@@ -1426,7 +1426,7 @@ ls.menu.help.about = Acerca
 # About window from Top menu Help->About:  Title
 window.about.title = Créditos
 # About window from Top menu Help->About:  Text
-window.about.text = El desarrollo empezó en 2003 por parte de Thomas Werth & Volker Fischer. Desde 2006, este proyecto es de código abierto y desarrollado por diferentes desarrolladores.
+window.about.text = El desarrollo empezó en 2003 por parte de Thomas Werth & Volker Fischer.\nDesde 2006, este proyecto es de código abierto y desarrollado por diferentes desarrolladores.
 # About window from Top menu Help->About:  Text
 window.about.licence = Licencia
 ls.button.update.linux.pkg.warning = Estás ejecutando HO a través de un paquete instalado en tu sistema. Si actualizas HO a través de esta interfaz, tu sistema no será informado de la actualización del programa. \nPor tanto, existirá una discrepancia entre la versión de HO informada por tu sistema y la que efectivamente está instalada y en uso (en el caso que haga falta una nueva dependencia de Java, tu sistema no la instalará automáticamente).\nNo obstante, esto no debería tener consecuencias y en caso de problemas siempre tendrás la posibilidad de instalar/actualizar HO encima de la instalación existente usando un paquete.\nAún quieres continuar?


### PR DESCRIPTION
I saw in the UI in the "Help"/"About" dialog that the text pointing to the start of the project started looks different in other languages.
To make it homogeneous like in the base language English I added a line break to all other languages where it was missing.

Additionally I corrected the years for danish because there were different years,