### PR TITLE
fix: Prevent exception on saving a change in the 'Formulas'

### DIFF
--- a/src/main/java/core/option/FormelPanel.java
+++ b/src/main/java/core/option/FormelPanel.java
@@ -44,6 +44,7 @@ final class FormelPanel extends ImagePanel implements ActionListener, ItemListen
     private SliderPanel m_jpTorwart;
     private SliderPanel m_jpVerteidigung;
     private SliderPanel m_jpNORMALISATIONFACTOR;
+    private boolean isStored;
 
     //~ Constructors -------------------------------------------------------------------------------
 
@@ -160,6 +161,7 @@ final class FormelPanel extends ImagePanel implements ActionListener, ItemListen
         m_jpVerteidigung.setValue(factorObject.getDEfactor());
         m_jpStandard.setValue(factorObject.getSPfactor());
         m_jpNORMALISATIONFACTOR.setValue(factorObject.getNormalizationFactor());
+        isStored = factorObject.isStored();
 
         m_jpSpielaufbau.addChangeListener(this);
         m_jpFluegelspiel.addChangeListener(this);
@@ -177,14 +179,15 @@ final class FormelPanel extends ImagePanel implements ActionListener, ItemListen
     	final FormulaFactors factors = FormulaFactors.instance();
         final FactorObject factorObject = new FactorObject((byte) (((CBItem) Objects.requireNonNull(m_jcbPosition
                 .getSelectedItem())).getId()),
-                                                           m_jpTorwart.getValue(),
-                                                           m_jpSpielaufbau.getValue(),
-                                                           m_jpPasspiel.getValue(),
-                                                           m_jpFluegelspiel.getValue(),
-                                                           m_jpVerteidigung.getValue(),
-                                                           m_jpTorschuss.getValue(),
-                                                           m_jpStandard.getValue(),
-                                                           m_jpNORMALISATIONFACTOR.getValue());
+                m_jpTorwart.getValue(),
+                m_jpSpielaufbau.getValue(),
+                m_jpPasspiel.getValue(),
+                m_jpFluegelspiel.getValue(),
+                m_jpVerteidigung.getValue(),
+                m_jpTorschuss.getValue(),
+                m_jpStandard.getValue(),
+                m_jpNORMALISATIONFACTOR.getValue());
+        factorObject.setIsStored(isStored);
 
         factors.setPositionFactor(factorObject.getPosition(),factorObject);
         OptionManager.instance().setReInitNeeded();

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -1,15 +1,15 @@
-
-
 ## Highlights
-* Calculation of the tsi sub by approximating the tsi formula (#235)
 
+* Calculation of the tsi sub by approximating the tsi formula (#235)
 
 ## [Detailed Changelog](https://github.com/ho-dev/HattrickOrganizer/issues?q=milestone%3A9.0)
 
 ### Database
+
 * Increase match report column size (#2065)
 
 ### Squad
+
 * Calculation of the tsi sub by approximating the tsi formula (#235)
 
 ### Team Analyzer
@@ -27,11 +27,14 @@
 ### Training
 
 ### International Friendlies
+
 * Fix database error on match reload (#2063)
 
 ### Youth
 
 ### Option setting
+
+* Fix: `Preferences/Formulas`: When changing anything and saving it, the application does not crash anymore during quit.
 
 ### Misc
 


### PR DESCRIPTION
1. changes proposed in this pull request:
   - 'Preferences/Formulas': When changing anything and saving it, the application does not crash anymore during quit.


2. `src/main/resources/release_notes.md` ...

 - [x] has been updated