### PR TITLE
fix: correcting PlayerAbilityTest due to refactoring of the translation functionality

### DIFF
--- a/src/main/java/core/model/Translator.java
+++ b/src/main/java/core/model/Translator.java
@@ -16,6 +16,7 @@ public class Translator {
 
     public static final String LANGUAGE_RESOURCE_PATH = "language";
     public static final String LANGUAGE_DEFAULT = "English";
+    public static final String LANGUAGE_NO_TRANSLATION = "NoTranslation";
     public static final String LANGUAGE_FILE_EXTENSION = "properties";
 
     private static final String LANGUAGE_SUPPORTED_LANGUAGES_FILENAME = "ListLanguages.txt";
@@ -110,7 +111,7 @@ public class Translator {
             return temp;
 
         // Search in properties of default language if nothing found and active language not the default
-        if (!isDefaultLanguage()) {
+        if (!isDefaultLanguage() && !isNoTranslation()) {
             ResourceBundle tempBundle = loadDefault().getResourceBundle();
 
             try {
@@ -129,6 +130,10 @@ public class Translator {
 
     private boolean isDefaultLanguage() {
         return getLanguage().equalsIgnoreCase(LANGUAGE_DEFAULT);
+    }
+
+    private boolean isNoTranslation() {
+        return getLanguage().equalsIgnoreCase(LANGUAGE_NO_TRANSLATION);
     }
 
     /**

--- a/src/test/java/core/constants/player/PlayerAbilityTest.kt
+++ b/src/test/java/core/constants/player/PlayerAbilityTest.kt
@@ -2,6 +2,7 @@ package core.constants.player
 
 import core.HOModelBuilder
 import core.model.HOVerwaltung
+import core.model.Translator
 import core.util.Helper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -16,7 +17,7 @@ class PlayerAbilityTest {
             .hrfId(42)
             .build()
         hoAdmin.model = hoModel
-        hoAdmin.clearTranslator();
+        hoAdmin.setTranslator(Translator.LANGUAGE_NO_TRANSLATION)
     }
 
     @Test

--- a/src/test/java/core/util/HODateTimeTest.java
+++ b/src/test/java/core/util/HODateTimeTest.java
@@ -1,8 +1,5 @@
 package core.util;
 
-import core.HO;
-import core.model.HOVerwaltung;
-import core.model.Translator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -11,11 +8,6 @@ public class HODateTimeTest {
 
         @Test
         public void test() {
-
-            HO.setPortable_version(true);
-            HOVerwaltung.instance().loadLatestHoModel();
-            HOVerwaltung.instance().setTranslator(Translator.LANGUAGE_DEFAULT);
-
             var nextTraining = HODateTime.fromHT("2022-03-31 08:30:00");
             var localDateTime = nextTraining.toLocaleDateTime();
             var previousTraining = nextTraining.plusDaysAtSameLocalTime(-7);


### PR DESCRIPTION
Correcting PlayerAbilityTest due to refactoring of the translation functionality that was committed with 381835ecbd1c4b05079149dbbd2e343eca3f6e5c

1. changes proposed in this pull request:
- corrects the PlayerAbilityTest by introducing a Translator.NoTranslation that means no translation

2. `src/main/resources/release_notes.md` ...
- [x] does not require update

3. [Optional] suggested person to review this PR @wsbrenk 