### PR TITLE
Refactor: Use import of class from java.util or remove superfluous qualification

### DIFF
--- a/src/main/java/core/file/ExampleFileFilter.java
+++ b/src/main/java/core/file/ExampleFileFilter.java
@@ -34,6 +34,7 @@ package core.file;
 import java.io.File;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.Locale;
 
 
 /**
@@ -187,7 +188,7 @@ public class ExampleFileFilter extends javax.swing.filechooser.FileFilter
             final int i = filename.lastIndexOf('.');
 
             if ((i > 0) && (i < (filename.length() - 1))) {
-                return filename.substring(i + 1).toLowerCase(java.util.Locale.ENGLISH);
+                return filename.substring(i + 1).toLowerCase(Locale.ENGLISH);
             }
 
         }
@@ -256,7 +257,7 @@ public class ExampleFileFilter extends javax.swing.filechooser.FileFilter
             filters = new Hashtable<>(5);
         }
 
-        filters.put(extension.toLowerCase(java.util.Locale.ENGLISH), this);
+        filters.put(extension.toLowerCase(Locale.ENGLISH), this);
         fullDescription = null;
     }
 

--- a/src/main/java/core/file/ZipHelper.java
+++ b/src/main/java/core/file/ZipHelper.java
@@ -8,6 +8,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Enumeration;
+import java.util.Locale;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
@@ -48,8 +49,8 @@ public class ZipHelper {
 		while (e.hasMoreElements()) {
 			ZipEntry entry = (ZipEntry) e.nextElement();
 			String fileName = destDir + File.separatorChar + entry.getName();
-			if (fileName.toUpperCase(java.util.Locale.ENGLISH).endsWith(
-					entryName.toUpperCase(java.util.Locale.ENGLISH))) {
+			if (fileName.toUpperCase(Locale.ENGLISH).endsWith(
+					entryName.toUpperCase(Locale.ENGLISH))) {
 				saveEntry(zipFile, entry, fileName);
 			}
 		}

--- a/src/main/java/core/file/hrf/HRFStringParser.java
+++ b/src/main/java/core/file/hrf/HRFStringParser.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 
 public class HRFStringParser {
@@ -109,7 +110,7 @@ public class HRFStringParser {
 							properties = new HOProperties();
 						}
 						properties.setProperty(lineString.substring(0, indexEqualsSign)
-								.toLowerCase(java.util.Locale.ENGLISH), lineString
+								.toLowerCase(Locale.ENGLISH), lineString
 								.substring(indexEqualsSign + 1));
 					}
 				}

--- a/src/main/java/core/model/series/Liga.java
+++ b/src/main/java/core/model/series/Liga.java
@@ -3,6 +3,8 @@ package core.model.series;
 
 import core.db.AbstractTable;
 
+import java.util.Properties;
+
 /**
  * Enthält alle Ligadaten
  */
@@ -33,7 +35,7 @@ public final class Liga extends AbstractTable.Storable {
     /**
      * Creates a new Liga object.
      */
-    public Liga(java.util.Properties properties) {
+    public Liga(Properties properties) {
         m_sLiga = properties.getProperty("serie", "");
 
         try {

--- a/src/main/java/core/net/DownloadDialog.java
+++ b/src/main/java/core/net/DownloadDialog.java
@@ -26,6 +26,7 @@ import tool.updater.UpdateController;
 import java.awt.*;
 import java.awt.event.*;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -164,7 +165,7 @@ public class DownloadDialog extends JDialog implements ActionListener {
 			m_jchMatchArchive.setOpaque(false);
 			matchArchivePanel.add(m_jchMatchArchive, BorderLayout.WEST);
 
-			m_clSpinnerModel.setCalendarField(java.util.Calendar.MONTH);
+			m_clSpinnerModel.setCalendarField(Calendar.MONTH);
 			((JSpinner.DateEditor) m_jsSpinner.getEditor()).getFormat().applyPattern("dd.MM.yyyy");
 			matchArchivePanel.add(m_jsSpinner, BorderLayout.EAST);
 

--- a/src/main/java/core/net/MyConnector.java
+++ b/src/main/java/core/net/MyConnector.java
@@ -399,10 +399,10 @@ public class MyConnector {
 		GregorianCalendar cal = new GregorianCalendar();
 		cal.setTimeInMillis(System.currentTimeMillis());
 		if (upcoming) {
-			cal.add(java.util.Calendar.MONTH, 5);
+			cal.add(Calendar.MONTH, 5);
 		}
 		// Paranoia against inaccurate system clock.
-		cal.add(java.util.Calendar.DAY_OF_MONTH, 1);
+		cal.add(Calendar.DAY_OF_MONTH, 1);
 
 		url += "&LastMatchDate=";
 		url += new SimpleDateFormat("yyyy-MM-dd").format(cal.getTime());

--- a/src/main/java/core/net/OnlineWorker.java
+++ b/src/main/java/core/net/OnlineWorker.java
@@ -940,7 +940,7 @@ public class OnlineWorker {
 				if (indexEqualsSign > 0) {
 					properties.setProperty(
 							lineString.substring(0, indexEqualsSign).toLowerCase(
-									java.util.Locale.ENGLISH),
+									Locale.ENGLISH),
 							lineString.substring(indexEqualsSign + 1));
 				}
 			}

--- a/src/main/java/core/option/InitOptionsDialog.java
+++ b/src/main/java/core/option/InitOptionsDialog.java
@@ -5,6 +5,7 @@ import core.model.Translator;
 
 import java.awt.BorderLayout;
 import java.awt.GridLayout;
+import java.util.Arrays;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -61,7 +62,7 @@ public final class InitOptionsDialog extends JDialog implements java.awt.event.A
         final String[] sprachdateien = Translator.getSupportedLanguages();
 
         try {
-            java.util.Arrays.sort(sprachdateien);
+            Arrays.sort(sprachdateien);
         } catch (Exception e) {
         }
 

--- a/src/main/java/core/option/ReleaseChannelPanel.java
+++ b/src/main/java/core/option/ReleaseChannelPanel.java
@@ -10,6 +10,7 @@ import javax.swing.event.ChangeEvent;
 import java.awt.*;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.util.Locale;
 
 /**
  * Controls for release channel with description
@@ -49,7 +50,7 @@ public final class ReleaseChannelPanel extends ImagePanel {
 				core.model.UserParameter.temp().ReleaseChannel = ReleaseChannelLabel;
 				m_jta_Description.setText(
 						core.model.HOVerwaltung.instance().getLanguageString("options.release_channels_" +
-								source.getText().toUpperCase(java.util.Locale.ENGLISH) + "_desc")
+								source.getText().toUpperCase(Locale.ENGLISH) + "_desc")
 				);
 				rc = Updater.ReleaseChannel.byLabel(ReleaseChannelLabel);
 			}

--- a/src/main/java/core/rating/RatingPredictionParameter.java
+++ b/src/main/java/core/rating/RatingPredictionParameter.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.Locale;
 import java.util.Properties;
 
 public class RatingPredictionParameter  {
@@ -45,7 +46,7 @@ public class RatingPredictionParameter  {
 					String line;
 					Properties curProperties = null;
 					while((line = br.readLine()) != null) {
-						line = line.toLowerCase(java.util.Locale.ENGLISH);
+						line = line.toLowerCase(Locale.ENGLISH);
 						// # begins a Comment
 						line = line.replaceFirst ("#.*", "");
 						// Trim
@@ -102,8 +103,8 @@ public class RatingPredictionParameter  {
     }
     
     public double getParam (String section, String key, double defVal) {
-    	key = key.toLowerCase(java.util.Locale.ENGLISH);
-    	section = section.toLowerCase(java.util.Locale.ENGLISH);
+    	key = key.toLowerCase(Locale.ENGLISH);
+    	section = section.toLowerCase(Locale.ENGLISH);
     	if (allProps.containsKey(section)) {
     		Properties props = allProps.get(section);
     		String propString = props.getProperty(key, "" + defVal);

--- a/src/main/java/core/util/Helper.java
+++ b/src/main/java/core/util/Helper.java
@@ -10,6 +10,7 @@ import core.model.player.MatchRoleID;
 import java.awt.*;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.util.Arrays;
 import java.util.Vector;
 import javax.swing.*;
 
@@ -284,7 +285,7 @@ public class Helper {
 				sortSpalte[i] = toSort[i][spaltenindex];
 			}
 
-			java.util.Arrays.sort(sortSpalte);
+			Arrays.sort(sortSpalte);
 
 			// scan all entries, search value in toSort and copy the value to the result
 			for (int i = 0; i < toSort.length; i++) {

--- a/src/main/java/module/transfer/scout/PlayerConverter.java
+++ b/src/main/java/module/transfer/scout/PlayerConverter.java
@@ -66,27 +66,27 @@ public class PlayerConverter {
         try{
             // Get all skills for active language
             // This should be the same language as in Hattrick
-            skills.add(homodel.getLanguageString("ls.player.skill.value.non-existent").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.disastrous").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.wretched").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.poor").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.weak").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.inadequate").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.passable").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.solid").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.excellent").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.formidable").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.outstanding").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.brilliant").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.magnificent").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.worldclass").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.supernatural").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.titanic").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.extra-terrestrial").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.mythical").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.magical").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.utopian").toLowerCase(java.util.Locale.ENGLISH));
-            skills.add(homodel.getLanguageString("ls.player.skill.value.divine").toLowerCase(java.util.Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.non-existent").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.disastrous").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.wretched").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.poor").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.weak").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.inadequate").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.passable").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.solid").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.excellent").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.formidable").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.outstanding").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.brilliant").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.magnificent").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.worldclass").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.supernatural").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.titanic").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.extra-terrestrial").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.mythical").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.magical").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.utopian").toLowerCase(Locale.ENGLISH));
+            skills.add(homodel.getLanguageString("ls.player.skill.value.divine").toLowerCase(Locale.ENGLISH));
 
             for (int k = 0; k < skills.size(); k++) {
                 skillvalues.add(k);
@@ -116,17 +116,17 @@ public class PlayerConverter {
             // Get all specialities for active language
             // This should be the same language as in Hattrick
             specialities.add(""); // No speciality
-            specialities.add(homodel.getLanguageString("ls.player.speciality.technical").toLowerCase(java.util.Locale.ENGLISH));
-            specialities.add(homodel.getLanguageString("ls.player.speciality.quick").toLowerCase(java.util.Locale.ENGLISH));
-            specialities.add(homodel.getLanguageString("ls.player.speciality.powerful").toLowerCase(java.util.Locale.ENGLISH));
-            specialities.add(homodel.getLanguageString("ls.player.speciality.unpredictable").toLowerCase(java.util.Locale.ENGLISH));
-            specialities.add(homodel.getLanguageString("ls.player.speciality.head").toLowerCase(java.util.Locale.ENGLISH));
-            specialities.add(homodel.getLanguageString("ls.player.speciality.regainer").toLowerCase(java.util.Locale.ENGLISH));
-            specialities.add(homodel.getLanguageString("ls.player.speciality.support").toLowerCase(java.util.Locale.ENGLISH));
+            specialities.add(homodel.getLanguageString("ls.player.speciality.technical").toLowerCase(Locale.ENGLISH));
+            specialities.add(homodel.getLanguageString("ls.player.speciality.quick").toLowerCase(Locale.ENGLISH));
+            specialities.add(homodel.getLanguageString("ls.player.speciality.powerful").toLowerCase(Locale.ENGLISH));
+            specialities.add(homodel.getLanguageString("ls.player.speciality.unpredictable").toLowerCase(Locale.ENGLISH));
+            specialities.add(homodel.getLanguageString("ls.player.speciality.head").toLowerCase(Locale.ENGLISH));
+            specialities.add(homodel.getLanguageString("ls.player.speciality.regainer").toLowerCase(Locale.ENGLISH));
+            specialities.add(homodel.getLanguageString("ls.player.speciality.support").toLowerCase(Locale.ENGLISH));
 
             for (int i = 0; i<PlayerSpeciality.ITEMS.length; i++){
                 for (int k = 0; k < 8; k++) {
-                    if(PlayerSpeciality.ITEMS[i].getText().toLowerCase(java.util.Locale.ENGLISH).equals(specialities.get(k))){
+                    if(PlayerSpeciality.ITEMS[i].getText().toLowerCase(Locale.ENGLISH).equals(specialities.get(k))){
                         specialitiesvalues.add(PlayerSpeciality.ITEMS[i].getId());
                         break;
                     }
@@ -324,7 +324,7 @@ Mindestgebot: [money]0[/money]
         sc.close();
         //Analyze Player Description
         row = rows.get(indexRowExperience);
-        sc = new Scanner(row.toLowerCase(java.util.Locale.ENGLISH));
+        sc = new Scanner(row.toLowerCase(Locale.ENGLISH));
         Pattern pattern = Pattern.compile(" |\\.");
         sc.useDelimiter(pattern);
         // Experience
@@ -415,7 +415,7 @@ Mindestgebot: [money]0[/money]
 
 
         // Speciality
-        row = rows.get(indexRowSpecialty).toLowerCase(java.util.Locale.ENGLISH);
+        row = rows.get(indexRowSpecialty).toLowerCase(Locale.ENGLISH);
         for (int index = 1; index < specialities.size(); index++) {
             if (row.contains(specialities.get(index))) {
                 player.setSpeciality(specialitiesvalues.get(index));
@@ -986,11 +986,11 @@ Mindestgebot: [money]0[/money]
 
             char[] cs = new char[teamname.length()];
             Arrays.fill(cs, '*');
-            mytext = mytext.replaceAll(Pattern.quote(teamname), new String(cs)).toLowerCase(java.util.Locale.ENGLISH);
+            mytext = mytext.replaceAll(Pattern.quote(teamname), new String(cs)).toLowerCase(Locale.ENGLISH);
 
             cs = new char[name.length()];
             Arrays.fill(cs, '*');
-            mytext = mytext.replaceAll(Pattern.quote(name.toLowerCase(java.util.Locale.ENGLISH)), new String(cs)).toLowerCase(java.util.Locale.ENGLISH);
+            mytext = mytext.replaceAll(Pattern.quote(name.toLowerCase(Locale.ENGLISH)), new String(cs)).toLowerCase(Locale.ENGLISH);
 
             // We can search all the skills in text now
             p = skills.size() - 1;

--- a/src/main/java/tool/arenasizer/Stadium.java
+++ b/src/main/java/tool/arenasizer/Stadium.java
@@ -3,6 +3,8 @@ package tool.arenasizer;
 import core.db.AbstractTable;
 import org.apache.commons.lang3.math.NumberUtils;
 
+import java.util.Properties;
+
 /**
  * Enthält die Stadiendaten
  */
@@ -57,7 +59,7 @@ public class Stadium extends AbstractTable.Storable {
     /**
      * Creates a new Stadium object.
      */
-    public Stadium(java.util.Properties properties) {
+    public Stadium(Properties properties) {
         m_sStadienname = properties.getProperty("arenaname", "");
         m_iStadiumId = NumberUtils.toInt(properties.getProperty("arenaid"),0);
         //m_iGesamtgroesse = NumberUtils.toInt(properties.getProperty("seattotal"),0);


### PR DESCRIPTION
1. changes proposed in this pull request:
- Use import of class from java.util or remove superfluous qualification

2. `src/main/resources/release_notes.md` ...
 - [x] does not require update

3. [Optional] suggested person to review this PR @wsbrenk 