### PR TITLE
[BUG] #2137: Download dialog does not reappear after being closed using the 'X' button

### DIFF
--- a/src/main/java/core/net/DownloadDialog.java
+++ b/src/main/java/core/net/DownloadDialog.java
@@ -65,6 +65,10 @@ public class DownloadDialog extends JDialog implements ActionListener {
 		return m_clDownloadDialog;
 	}
 
+	private static void clearInstance() {
+		m_clDownloadDialog = null;
+	}
+
 	/**
 	 * Singleton
 	 */
@@ -99,7 +103,12 @@ public class DownloadDialog extends JDialog implements ActionListener {
 	private void close(){
 		setVisible(false);
 		dispose();
-		m_clDownloadDialog = null;
+	}
+
+	@Override
+	public void dispose() {
+		super.dispose();
+		clearInstance();
 	}
 
 	/**

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -38,6 +38,9 @@
 
 ### Misc
 
+* Fix #2137: Resolved an issue where the Download Dialog would not reappear after being closed with the 'X' button. The
+  dialog will now correctly reappear when triggered again.
+
 ## Translations
 
 Reports by Contributors - June 23, 2024 - July 01, 2024


### PR DESCRIPTION
1. changes proposed in this pull request:
   - fixes issue #2137 

2. `src/main/resources/release_notes.md` ...
 - [x] has been updated

3. [Optional] suggested person to review this PR @wsbrenk
