### PR TITLE
[BUG] #2139: Fix wrong translation for Spanish for 'worstOfSeason'

### DIFF
--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -12,8 +12,15 @@
 * Fix sql error when youth scout comment is too long for the database column (#2094)
 * Fix exception on examining youth player substitutions (#2097)
 
-
 ## Translations
+
+### Specific
+
+#### Spanish
+
+* [#2139](https://github.com/ho-dev/HattrickOrganizer/issues/2139): Fix translation for `worstOfSeason`
+
+### General
 
 Reports by Contributors - June 23, 2024 - July 20, 2024
 


### PR DESCRIPTION
1. changes proposed in this pull request:
- fixes issue #2139

2. `src/main/resources/release_notes.md` ...
- [x] has been updated

3. [Optional] suggested person to review this PR @wsbrenk
I've made the changes also in POEditor...