### PR TITLE
Fix: Correct contract of equals and hashCode of HODateTime

### DIFF
--- a/src/main/java/core/util/HODateTime.java
+++ b/src/main/java/core/util/HODateTime.java
@@ -206,7 +206,25 @@ public class HODateTime implements Comparable<HODateTime> {
         return instant.compareTo(o.instant);
     }
 
-    public boolean equals(HODateTime t){ return this.instant.equals(t.instant);}
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o instanceof HODateTime that) {
+            return that.canEqual(this) && instant.equals(that.instant);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return instant.hashCode();
+    }
+
+    protected boolean canEqual(Object o) {
+        return o instanceof HODateTime;
+    }
 
     public HODateTime minus(int i, ChronoUnit unit) {
         return new HODateTime(instant.minus(i, unit));

--- a/src/test/java/core/util/HODateTimeTest.java
+++ b/src/test/java/core/util/HODateTimeTest.java
@@ -2,9 +2,25 @@ package core.util;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.data.Offset.offset;
 
 class HODateTimeTest {
 
+    private static final HODateTime HO_DATE_TIME = HODateTime.fromHT("2024-01-01 00:00:00");
 
         @Test
         void test() {
@@ -57,4 +73,76 @@ class HODateTimeTest {
             Assertions.assertEquals(dti.toHTWeek().week, 1);
 
         }
+
+    static Stream<Arguments> equals() {
+        return Stream.of(
+                Arguments.of(HODateTime.fromHT("2024-10-30 20:00:00"), HODateTime.fromHT("2025-10-30 20:00:00"), false),
+                Arguments.of(HODateTime.fromHT("2024-10-30 20:00:00"), HODateTime.fromHT("2024-11-30 20:00:00"), false),
+                Arguments.of(HODateTime.fromHT("2024-10-30 20:00:00"), HODateTime.fromHT("2024-10-31 20:00:00"), false),
+                Arguments.of(HODateTime.fromHT("2024-10-30 20:00:00"), HODateTime.fromHT("2024-10-30 21:00:00"), false),
+                Arguments.of(HODateTime.fromHT("2024-10-30 20:00:00"), HODateTime.fromHT("2024-10-30 20:01:00"), false),
+                Arguments.of(HODateTime.fromHT("2024-10-30 20:00:00"), HODateTime.fromHT("2024-10-30 20:00:01"), false),
+                Arguments.of(HO_DATE_TIME, HO_DATE_TIME, true),
+                Arguments.of(HODateTime.fromHT("2024-10-30 20:00:00"), HODateTime.fromHT("2024-10-30 20:00:00"), true),
+                Arguments.of(HO_DATE_TIME, null, false)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void equals(HODateTime lhs, HODateTime rhs, boolean result) {
+        assertThat(lhs.equals(rhs)).isEqualTo(result);
+    }
+
+
+    @Test
+    void testHashCode_consistencyOnTwoCalls() {
+        // given
+        final var now = HODateTime.now();
+
+        // when
+        final var hashCode1 = now.hashCode();
+        final var hashCode2 = now.hashCode();
+
+        // then
+        assertThat(hashCode1).isEqualTo(hashCode2);
+    }
+
+    @Test
+    void testHashCode_twoEqualObjectsResultsEqualHashCodes() {
+        // given
+        final var htTimeString = "2024-12-31 23:59:59";
+        final var hoDateTime1 = HODateTime.fromHT(htTimeString);
+        final var hoDateTime2 = HODateTime.fromHT(htTimeString);
+
+        // when
+        final var hashCode1 = hoDateTime1.hashCode();
+        final var hashCode2 = hoDateTime2.hashCode();
+
+        // then
+        assertThat(hashCode1).isEqualTo(hashCode2);
+    }
+
+    @Test
+    void testHashCode_givenMultipleObjects_whenTestingHashCodeDistribution_thenEvenDistributionOfHashCodes() {
+        // given
+        final var localDateTime = LocalDateTime.now();
+        final var objects = IntStream.range(0, 1000).mapToObj(i -> generate(i, localDateTime)).toList();
+
+        // when
+        final Set<Integer> hashCodes = objects.stream().map(Objects::hashCode).collect(Collectors.toSet());
+
+        // then
+        assertThat(hashCodes.size()).isCloseTo( objects.size(), offset(10));
+    }
+
+    private static HODateTime generate(int i, LocalDateTime localDateTime) {
+        return fromLocalDateTime(localDateTime.plusDays(i));
+    }
+
+    private static HODateTime fromLocalDateTime(LocalDateTime localDateTime) {
+        final var zonedDateTime = ZonedDateTime.of(localDateTime, ZoneId.systemDefault());
+        zonedDateTime.withZoneSameInstant(HODateTime.DEFAULT_TIMEZONE);
+        return new HODateTime(zonedDateTime.toInstant());
+    }
 }


### PR DESCRIPTION
1. changes proposed in this pull request:
- The contract of the 'equals' and 'hashCode' function of class 'HODateTime' was violated. It is now possible to use e.g. 'HODateTime' in 'HashSet' or in native test code for equality checks.

2. `src/main/resources/release_notes.md` ...
 - [x] does not require update

3. [Optional] suggested person to review this PR @___
