### PR TITLE
refactor: Remove unnecessary qualification java lang

### DIFF
--- a/src/main/java/core/gui/language/LanguageTableModel.java
+++ b/src/main/java/core/gui/language/LanguageTableModel.java
@@ -142,7 +142,7 @@ public class LanguageTableModel extends AbstractTableModel implements TableModel
 	}
 	
 	/* (non-Javadoc)
-	 * @see javax.swing.table.AbstractTableModel#setValueAt(java.lang.Object, int, int)
+	 * @see javax.swing.table.AbstractTableModel#setValueAt(Object, int, int)
 	 */
 	@Override
 	public void setValueAt(Object aValue, int rowIndex, int columnIndex) {

--- a/src/main/java/core/gui/model/ArenaStatistikModel.java
+++ b/src/main/java/core/gui/model/ArenaStatistikModel.java
@@ -125,7 +125,7 @@ public class ArenaStatistikModel {
      *
      * @param m_sGastName New value of property m_sGastName.
      */
-    public final void setGastName(java.lang.String m_sGastName) {
+    public final void setGastName(String m_sGastName) {
         this.m_sGastName = m_sGastName;
     }
 
@@ -134,7 +134,7 @@ public class ArenaStatistikModel {
      *
      * @return Value of property m_sGastName.
      */
-    public final java.lang.String getGastName() {
+    public final String getGastName() {
         return m_sGastName;
     }
 
@@ -161,7 +161,7 @@ public class ArenaStatistikModel {
      *
      * @param m_sHeimName New value of property m_sHeimName.
      */
-    public final void setHeimName(java.lang.String m_sHeimName) {
+    public final void setHeimName(String m_sHeimName) {
         this.m_sHeimName = m_sHeimName;
     }
 
@@ -170,7 +170,7 @@ public class ArenaStatistikModel {
      *
      * @return Value of property m_sHeimName.
      */
-    public final java.lang.String getHeimName() {
+    public final String getHeimName() {
         return m_sHeimName;
     }
 

--- a/src/main/java/core/gui/model/PlayerMatchCBItem.java
+++ b/src/main/java/core/gui/model/PlayerMatchCBItem.java
@@ -77,7 +77,7 @@ public class PlayerMatchCBItem {
      *
      * @param m_clGastteam New value of property m_clGastteam.
      */
-    public final void setGastteam(java.lang.String m_clGastteam) {
+    public final void setGastteam(String m_clGastteam) {
         this.m_clGastteam = m_clGastteam;
     }
 
@@ -86,7 +86,7 @@ public class PlayerMatchCBItem {
      *
      * @return Value of property m_clGastteam.
      */
-    public final java.lang.String getGuestTeamName() {
+    public final String getGuestTeamName() {
         return m_clGastteam;
     }
 
@@ -113,7 +113,7 @@ public class PlayerMatchCBItem {
      *
      * @param m_clHeimteam New value of property m_clHeimteam.
      */
-    public final void setHeimteam(java.lang.String m_clHeimteam) {
+    public final void setHeimteam(String m_clHeimteam) {
         this.m_clHeimteam = m_clHeimteam;
     }
 
@@ -122,7 +122,7 @@ public class PlayerMatchCBItem {
      *
      * @return Value of property m_clHeimteam.
      */
-    public final java.lang.String getHomeTeamName() {
+    public final String getHomeTeamName() {
         return m_clHeimteam;
     }
 
@@ -239,7 +239,7 @@ public class PlayerMatchCBItem {
      *
      * @param m_sSelbstvertrauen New value of property m_sSelbstvertrauen.
      */
-    public final void setConfidence(java.lang.String m_sSelbstvertrauen) {
+    public final void setConfidence(String m_sSelbstvertrauen) {
         this.m_sSelbstvertrauen = m_sSelbstvertrauen;
     }
 
@@ -248,7 +248,7 @@ public class PlayerMatchCBItem {
      *
      * @return Value of property m_sSelbstvertrauen.
      */
-    public final java.lang.String getSelbstvertrauen() {
+    public final String getSelbstvertrauen() {
         return m_sSelbstvertrauen;
     }
 
@@ -275,7 +275,7 @@ public class PlayerMatchCBItem {
      *
      * @param m_sStimmung New value of property m_sStimmung.
      */
-    public final void setTeamSpirit(java.lang.String m_sStimmung) {
+    public final void setTeamSpirit(String m_sStimmung) {
         this.m_sTeamSpirit = m_sStimmung;
     }
 
@@ -284,7 +284,7 @@ public class PlayerMatchCBItem {
      *
      * @return Value of property m_sStimmung.
      */
-    public final java.lang.String getStimmung() {
+    public final String getStimmung() {
         return m_sTeamSpirit;
     }
 }

--- a/src/main/java/core/model/StaffMember.java
+++ b/src/main/java/core/model/StaffMember.java
@@ -56,7 +56,7 @@ public class StaffMember extends AbstractTable.Storable implements Comparable<St
 	}
 	
 	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
+	 * @see Object#toString()
 	 */
 	@Override
 	public String toString() {

--- a/src/main/java/core/model/match/MatchLineupTeam.java
+++ b/src/main/java/core/model/match/MatchLineupTeam.java
@@ -269,7 +269,7 @@ public class MatchLineupTeam extends AbstractTable.Storable {
 	 * @param m_sTeamName
 	 *            New value of property m_sTeamName.
 	 */
-	public final void setTeamName(java.lang.String m_sTeamName) {
+	public final void setTeamName(String m_sTeamName) {
 		this.teamName = m_sTeamName;
 	}
 
@@ -278,7 +278,7 @@ public class MatchLineupTeam extends AbstractTable.Storable {
 	 * 
 	 * @return Value of property m_sTeamName.
 	 */
-	public final java.lang.String getTeamName() {
+	public final String getTeamName() {
 		return teamName;
 	}
 

--- a/src/main/java/core/model/match/Matchdetails.java
+++ b/src/main/java/core/model/match/Matchdetails.java
@@ -556,7 +556,7 @@ public class Matchdetails extends AbstractTable.Storable implements core.model.m
      *
      * @param m_sArenaName New value of property m_sArenaName.
      */
-    public final void setArenaName(java.lang.String m_sArenaName) {
+    public final void setArenaName(String m_sArenaName) {
         this.m_sArenaName = m_sArenaName;
     }
 
@@ -565,7 +565,7 @@ public class Matchdetails extends AbstractTable.Storable implements core.model.m
      *
      * @return Value of property m_sArenaName.
      */
-    public final java.lang.String getArenaName() {
+    public final String getArenaName() {
         return m_sArenaName;
     }
 
@@ -635,7 +635,7 @@ public class Matchdetails extends AbstractTable.Storable implements core.model.m
      *
      * @param m_sGastName New value of property m_sGastName.
      */
-    public final void setGastName(java.lang.String m_sGastName) {
+    public final void setGastName(String m_sGastName) {
         this.m_sGastName = m_sGastName;
     }
 
@@ -644,7 +644,7 @@ public class Matchdetails extends AbstractTable.Storable implements core.model.m
      *
      * @return Value of property m_sGastName.
      */
-    public final java.lang.String getGuestTeamName() {
+    public final String getGuestTeamName() {
         return m_sGastName;
     }
 
@@ -916,7 +916,7 @@ public class Matchdetails extends AbstractTable.Storable implements core.model.m
      *
      * @param m_sHeimName New value of property m_sHeimName.
      */
-    public final void setHeimName(java.lang.String m_sHeimName) {
+    public final void setHeimName(String m_sHeimName) {
         this.m_sHeimName = m_sHeimName;
     }
 
@@ -925,7 +925,7 @@ public class Matchdetails extends AbstractTable.Storable implements core.model.m
      *
      * @return Value of property m_sHeimName.
      */
-    public final java.lang.String getHomeTeamName() {
+    public final String getHomeTeamName() {
         return m_sHeimName;
     }
 
@@ -1280,7 +1280,7 @@ public class Matchdetails extends AbstractTable.Storable implements core.model.m
      *
      * @param m_sMatchreport New value of property m_sMatchreport.
      */
-    public final void setMatchreport(java.lang.String m_sMatchreport) {
+    public final void setMatchreport(String m_sMatchreport) {
         this.m_sMatchreport = m_sMatchreport;
     }
 
@@ -1289,7 +1289,7 @@ public class Matchdetails extends AbstractTable.Storable implements core.model.m
      *
      * @return Value of property m_sMatchreport.
      */
-    public final java.lang.String getMatchreport() {
+    public final String getMatchreport() {
         return m_sMatchreport;
     }
 

--- a/src/main/java/core/model/misc/Basics.java
+++ b/src/main/java/core/model/misc/Basics.java
@@ -193,7 +193,7 @@ public final class Basics extends AbstractTable.Storable {
      *
      * @param m_sManager New value of property m_sManager.
      */
-    public void setManager(java.lang.String m_sManager) {
+    public void setManager(String m_sManager) {
         this.m_sManager = m_sManager;
     }
 
@@ -202,7 +202,7 @@ public final class Basics extends AbstractTable.Storable {
      *
      * @return Value of property m_sManager.
      */
-    public java.lang.String getManager() {
+    public String getManager() {
         return m_sManager;
     }
 
@@ -297,7 +297,7 @@ public final class Basics extends AbstractTable.Storable {
      *
      * @param m_sTeamName New value of property m_sTeamName.
      */
-    public void setTeamName(java.lang.String m_sTeamName) {
+    public void setTeamName(String m_sTeamName) {
         this.m_sTeamName = m_sTeamName;
     }
 
@@ -306,7 +306,7 @@ public final class Basics extends AbstractTable.Storable {
      *
      * @return Value of property m_sTeamName.
      */
-    public java.lang.String getTeamName() {
+    public String getTeamName() {
         return m_sTeamName;
     }
     

--- a/src/main/java/core/model/misc/Verein.java
+++ b/src/main/java/core/model/misc/Verein.java
@@ -315,7 +315,7 @@ public final class Verein extends AbstractTable.Storable {
      *
      * @param m_sTeamName New value of property m_sTeamName.
      */
-    public void setTeamName(java.lang.String m_sTeamName) {
+    public void setTeamName(String m_sTeamName) {
         this.m_sTeamName = m_sTeamName;
     }
 
@@ -324,7 +324,7 @@ public final class Verein extends AbstractTable.Storable {
      *
      * @return Value of property m_sTeamName.
      */
-    public java.lang.String getTeamName() {
+    public String getTeamName() {
         return m_sTeamName;
     }
   

--- a/src/main/java/core/model/series/Liga.java
+++ b/src/main/java/core/model/series/Liga.java
@@ -83,7 +83,7 @@ public final class Liga extends AbstractTable.Storable {
      *
      * @param m_sLiga New value of property m_sLiga.
      */
-    public void setLiga(java.lang.String m_sLiga) {
+    public void setLiga(String m_sLiga) {
         this.m_sLiga = m_sLiga;
     }
 
@@ -92,7 +92,7 @@ public final class Liga extends AbstractTable.Storable {
      *
      * @return Value of property m_sLiga.
      */
-    public java.lang.String getLiga() {
+    public String getLiga() {
         return m_sLiga;
     }
 

--- a/src/main/java/core/model/series/LigaTabelle.java
+++ b/src/main/java/core/model/series/LigaTabelle.java
@@ -71,7 +71,7 @@ public class LigaTabelle  {
      *
      * @param m_sLigaLandName New value of property m_sLigaLandName.
      */
-    public final void setLigaLandName(java.lang.String m_sLigaLandName) {
+    public final void setLigaLandName(String m_sLigaLandName) {
         this.m_sLigaLandName = m_sLigaLandName;
     }
 
@@ -80,7 +80,7 @@ public class LigaTabelle  {
      *
      * @param m_sLigaName New value of property m_sLigaName.
      */
-    public final void setLigaName(java.lang.String m_sLigaName) {
+    public final void setLigaName(String m_sLigaName) {
         this.m_sLigaName = m_sLigaName;
     }
 

--- a/src/main/java/core/model/series/Paarung.java
+++ b/src/main/java/core/model/series/Paarung.java
@@ -68,7 +68,7 @@ public class Paarung extends AbstractTable.Storable implements Comparable<Paarun
      *
      * @param m_sGastName New value of property m_sGastName.
      */
-    public final void setGastName(java.lang.String m_sGastName) {
+    public final void setGastName(String m_sGastName) {
         this.m_sGastName = m_sGastName;
     }
 
@@ -77,7 +77,7 @@ public class Paarung extends AbstractTable.Storable implements Comparable<Paarun
      *
      * @return Value of property m_sGastName.
      */
-    public final java.lang.String getGastName() {
+    public final String getGastName() {
         return m_sGastName;
     }
 
@@ -104,7 +104,7 @@ public class Paarung extends AbstractTable.Storable implements Comparable<Paarun
      *
      * @param m_sHeimName New value of property m_sHeimName.
      */
-    public final void setHeimName(java.lang.String m_sHeimName) {
+    public final void setHeimName(String m_sHeimName) {
         this.m_sHeimName = m_sHeimName;
     }
 
@@ -113,7 +113,7 @@ public class Paarung extends AbstractTable.Storable implements Comparable<Paarun
      *
      * @return Value of property m_sHeimName.
      */
-    public final java.lang.String getHeimName() {
+    public final String getHeimName() {
         return m_sHeimName;
     }
 

--- a/src/main/java/core/model/series/SerieTableEntry.java
+++ b/src/main/java/core/model/series/SerieTableEntry.java
@@ -352,7 +352,7 @@ public class SerieTableEntry implements Comparable<SerieTableEntry> {
      *
      * @param m_sTeamName New value of property m_sTeamName.
      */
-    public final void setTeamName(java.lang.String m_sTeamName) {
+    public final void setTeamName(String m_sTeamName) {
         this.m_sTeamName = m_sTeamName;
     }
 
@@ -361,7 +361,7 @@ public class SerieTableEntry implements Comparable<SerieTableEntry> {
      *
      * @return Value of property m_sTeamName.
      */
-    public final java.lang.String getTeamName() {
+    public final String getTeamName() {
         return m_sTeamName;
     }
 

--- a/src/main/java/core/model/series/TabellenVerlaufEintrag.java
+++ b/src/main/java/core/model/series/TabellenVerlaufEintrag.java
@@ -56,7 +56,7 @@ public class TabellenVerlaufEintrag {
      *
      * @param m_sTeamName New value of property m_sTeamName.
      */
-    public final void setTeamName(java.lang.String m_sTeamName) {
+    public final void setTeamName(String m_sTeamName) {
         this.m_sTeamName = m_sTeamName;
     }
 
@@ -65,7 +65,7 @@ public class TabellenVerlaufEintrag {
      *
      * @return Value of property m_sTeamName.
      */
-    public final java.lang.String getTeamName() {
+    public final String getTeamName() {
         return m_sTeamName;
     }
 }

--- a/src/main/java/core/prediction/MatchResultTable.java
+++ b/src/main/java/core/prediction/MatchResultTable.java
@@ -18,7 +18,7 @@ class MatchResultTable extends JTable {
 	MatchResultTable(MatchResult matchresults,boolean isHome) {
 		super();
 		initModel(matchresults,isHome);
-		setDefaultRenderer(java.lang.Object.class, new core.gui.comp.renderer.HODefaultTableCellRenderer());
+		setDefaultRenderer(Object.class, new core.gui.comp.renderer.HODefaultTableCellRenderer());
 		setSelectionBackground(core.gui.comp.renderer.HODefaultTableCellRenderer.SELECTION_BG);
 		setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
 	}

--- a/src/main/java/core/prediction/MatchScoreDiffTable.java
+++ b/src/main/java/core/prediction/MatchScoreDiffTable.java
@@ -18,7 +18,7 @@ class MatchScoreDiffTable extends JTable {
 	MatchScoreDiffTable(MatchResult mr,boolean isHome) {
 		super();
 		initModel(mr,isHome);
-		setDefaultRenderer(java.lang.Object.class, new core.gui.comp.renderer.HODefaultTableCellRenderer());
+		setDefaultRenderer(Object.class, new core.gui.comp.renderer.HODefaultTableCellRenderer());
 		setSelectionBackground(core.gui.comp.renderer.HODefaultTableCellRenderer.SELECTION_BG);
 		setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
 	}

--- a/src/main/java/core/prediction/MatchScoreTable.java
+++ b/src/main/java/core/prediction/MatchScoreTable.java
@@ -18,7 +18,7 @@ class MatchScoreTable extends JTable {
 	MatchScoreTable(MatchResult mr,boolean isHome) {
 		super();
 		initModel(mr,isHome);
-		setDefaultRenderer(java.lang.Object.class, new core.gui.comp.renderer.HODefaultTableCellRenderer());
+		setDefaultRenderer(Object.class, new core.gui.comp.renderer.HODefaultTableCellRenderer());
 		setSelectionBackground(core.gui.comp.renderer.HODefaultTableCellRenderer.SELECTION_BG);
 		setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
 	}

--- a/src/main/java/core/util/chart/LinesChartDataModel.java
+++ b/src/main/java/core/util/chart/LinesChartDataModel.java
@@ -139,7 +139,7 @@ public class LinesChartDataModel {
      *
      * @param m_sName New value of property m_sName.
      */
-    public final void setName(java.lang.String m_sName) {
+    public final void setName(String m_sName) {
         this.m_sName = m_sName;
     }
 
@@ -148,7 +148,7 @@ public class LinesChartDataModel {
      *
      * @return Value of property m_sName.
      */
-    public final java.lang.String getName() {
+    public final String getName() {
         return m_sName;
     }
 

--- a/src/main/java/module/matches/MatchesTable.java
+++ b/src/main/java/module/matches/MatchesTable.java
@@ -27,7 +27,7 @@ final class MatchesTable extends JTable {
 	protected MatchesTable(int matchtyp) {
 		super();
 		initModel(matchtyp, UserParameter.instance().matchLocation);
-		setDefaultRenderer(java.lang.Object.class, new HODefaultTableCellRenderer());
+		setDefaultRenderer(Object.class, new HODefaultTableCellRenderer());
 		getTableHeader().setDefaultRenderer(new TableHeaderRenderer1(this));
 		getTableHeader().setFont(getTableHeader().getFont().deriveFont(Font.BOLD));
 		setSelectionBackground(HODefaultTableCellRenderer.SELECTION_BG);

--- a/src/main/java/module/playerOverview/LineupPlayersTableNameColumn.java
+++ b/src/main/java/module/playerOverview/LineupPlayersTableNameColumn.java
@@ -26,7 +26,7 @@ public class LineupPlayersTableNameColumn extends JTable implements Refreshable,
 		model.addTableModelListener(this);
 		setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		setModel(new ReduzedTableModel(model, 0));
-		setDefaultRenderer(java.lang.Object.class, new HODefaultTableCellRenderer());
+		setDefaultRenderer(Object.class, new HODefaultTableCellRenderer());
 		RefreshManager.instance().registerRefreshable(this);
 		addMouseListener(new MouseAdapter() {
 			@Override

--- a/src/main/java/module/series/SeriesTablePanel.java
+++ b/src/main/java/module/series/SeriesTablePanel.java
@@ -165,7 +165,7 @@ class SeriesTablePanel extends ImagePanel {
 		// serie Table
 		constraints.gridy = 1;
 		constraints.insets = new Insets(0, 4, 4, 4);
-		seriesTable.setDefaultRenderer(java.lang.Object.class, new HODefaultTableCellRenderer());
+		seriesTable.setDefaultRenderer(Object.class, new HODefaultTableCellRenderer());
 		seriesTable.setRowHeight(30);
 		layout.setConstraints(seriesTable, constraints);
 		panel.add(seriesTable);

--- a/src/main/java/module/teamAnalyzer/ui/RecapTableRenderer.java
+++ b/src/main/java/module/teamAnalyzer/ui/RecapTableRenderer.java
@@ -23,7 +23,7 @@ public class RecapTableRenderer extends HODefaultTableCellRenderer {
 	 * 
 	 * @see
 	 * javax.swing.table.TableCellRenderer#getTableCellRendererComponent(javax
-	 * .swing.JTable, java.lang.Object, boolean, boolean, int, int)
+	 * .swing.JTable, Object, boolean, boolean, int, int)
 	 */
 	@Override
 	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {

--- a/src/main/java/module/teamAnalyzer/ui/RosterTableRenderer.java
+++ b/src/main/java/module/teamAnalyzer/ui/RosterTableRenderer.java
@@ -25,7 +25,7 @@ public class RosterTableRenderer extends DefaultTableCellRenderer {
      * (non-Javadoc)
      *
      * @see javax.swing.table.TableCellRenderer#getTableCellRendererComponent(javax.swing.JTable,
-     *      java.lang.Object, boolean, boolean, int, int)
+     *      Object, boolean, boolean, int, int)
      */
     @Override
     public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,

--- a/src/main/java/module/teamAnalyzer/ui/renderer/PlayerPositionTableCellRenderer.java
+++ b/src/main/java/module/teamAnalyzer/ui/renderer/PlayerPositionTableCellRenderer.java
@@ -31,7 +31,7 @@ public class PlayerPositionTableCellRenderer extends DefaultTableCellRenderer {
      * (non-Javadoc)
      *
      * @see javax.swing.table.TableCellRenderer#getTableCellRendererComponent(javax.swing.JTable,
-     *      java.lang.Object, boolean, boolean, int, int)
+     *      Object, boolean, boolean, int, int)
      */
     @Override
 	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,

--- a/src/main/java/module/training/PastTrainingManager.java
+++ b/src/main/java/module/training/PastTrainingManager.java
@@ -85,7 +85,7 @@ public class PastTrainingManager {
 	private static class SkillChangeComparator implements Comparator<SkillChange> {
 
 		/**
-		 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
+		 * @see java.util.Comparator#compare(Object, Object)
 		 */
 		@Override
 		public int compare(SkillChange o1, SkillChange o2) {

--- a/src/main/java/module/training/ui/TrainingRecapTable.java
+++ b/src/main/java/module/training/ui/TrainingRecapTable.java
@@ -148,7 +148,7 @@ public class TrainingRecapTable extends JScrollPane {
     private static class FixedTrainingRecapRenderer extends DefaultTableCellRenderer {
 
         /* (non-Javadoc)
-         * @see javax.swing.table.TableCellRenderer#getTableCellRendererComponent(javax.swing.JTable, java.lang.Object, boolean, boolean, int, int)
+         * @see javax.swing.table.TableCellRenderer#getTableCellRendererComponent(javax.swing.JTable, Object, boolean, boolean, int, int)
          */
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,

--- a/src/main/java/module/training/ui/renderer/ChangeTableRenderer.java
+++ b/src/main/java/module/training/ui/renderer/ChangeTableRenderer.java
@@ -24,7 +24,7 @@ public class ChangeTableRenderer extends DefaultTableCellRenderer {
 
     /**
      * @see javax.swing.table.TableCellRenderer#getTableCellRendererComponent(javax.swing.JTable,
-     *      java.lang.Object, boolean, boolean, int, int)
+     *      Object, boolean, boolean, int, int)
      */
     @Override
 	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,

--- a/src/main/java/module/training/ui/renderer/SkillupTableRenderer.java
+++ b/src/main/java/module/training/ui/renderer/SkillupTableRenderer.java
@@ -27,7 +27,7 @@ public class SkillupTableRenderer extends DefaultTableCellRenderer {
 	 * 
 	 * @see
 	 * javax.swing.table.TableCellRenderer#getTableCellRendererComponent(javax
-	 * .swing.JTable, java.lang.Object, boolean, boolean, int, int)
+	 * .swing.JTable, Object, boolean, boolean, int, int)
 	 */
 	@Override
 	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,

--- a/src/main/java/module/training/ui/renderer/SkillupTypeTableCellRenderer.java
+++ b/src/main/java/module/training/ui/renderer/SkillupTypeTableCellRenderer.java
@@ -24,7 +24,7 @@ public class SkillupTypeTableCellRenderer extends ChangeTableRenderer {
  
     /**
      * @see javax.swing.table.TableCellRenderer#getTableCellRendererComponent(javax.swing.JTable,
-     *      java.lang.Object, boolean, boolean, int, int)
+     *      Object, boolean, boolean, int, int)
      */
     @Override
 	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,

--- a/src/main/java/module/training/ui/renderer/SkillupsTableCellRenderer.java
+++ b/src/main/java/module/training/ui/renderer/SkillupsTableCellRenderer.java
@@ -27,7 +27,7 @@ public class SkillupsTableCellRenderer extends DefaultTableCellRenderer {
 
 	/**
      * @see javax.swing.table.TableCellRenderer#getTableCellRendererComponent(javax.swing.JTable,
-     *      java.lang.Object, boolean, boolean, int, int)
+     *      Object, boolean, boolean, int, int)
      */
     @Override
 	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,

--- a/src/main/java/module/training/ui/renderer/TrainingRecapRenderer.java
+++ b/src/main/java/module/training/ui/renderer/TrainingRecapRenderer.java
@@ -48,7 +48,7 @@ public class TrainingRecapRenderer extends DefaultTableCellRenderer {
 	//~ Methods ------------------------------------------------------------------------------------
 
     /* (non-Javadoc)
-     * @see javax.swing.table.TableCellRenderer#getTableCellRendererComponent(javax.swing.JTable, java.lang.Object, boolean, boolean, int, int)
+     * @see javax.swing.table.TableCellRenderer#getTableCellRendererComponent(javax.swing.JTable, Object, boolean, boolean, int, int)
      */
     @Override
 	public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,

--- a/src/main/java/module/transfer/scout/ScoutEintrag.java
+++ b/src/main/java/module/transfer/scout/ScoutEintrag.java
@@ -221,7 +221,7 @@ public class ScoutEintrag extends AbstractTable.Storable {
      *
      * @param m_sInfo New value of property m_sInfo.
      */
-    public final void setInfo(java.lang.String m_sInfo) {
+    public final void setInfo(String m_sInfo) {
         this.m_sInfo = m_sInfo;
     }
 
@@ -230,7 +230,7 @@ public class ScoutEintrag extends AbstractTable.Storable {
      *
      * @return Value of property m_sInfo.
      */
-    public final java.lang.String getInfo() {
+    public final String getInfo() {
         return m_sInfo;
     }
 
@@ -275,7 +275,7 @@ public class ScoutEintrag extends AbstractTable.Storable {
      *
      * @param m_sName New value of property m_sName.
      */
-    public final void setName(java.lang.String m_sName) {
+    public final void setName(String m_sName) {
         this.m_sName = m_sName;
     }
 
@@ -284,7 +284,7 @@ public class ScoutEintrag extends AbstractTable.Storable {
      *
      * @return Value of property m_sName.
      */
-    public final java.lang.String getName() {
+    public final String getName() {
         return m_sName;
     }
 

--- a/src/main/java/module/transfer/scout/TransferTable.java
+++ b/src/main/java/module/transfer/scout/TransferTable.java
@@ -23,7 +23,7 @@ public class TransferTable extends JTable implements Refreshable {
         super();
         m_clTableModel = new TransferTableModel(DBManager.instance().getScoutList());
         initModel();
-        setDefaultRenderer(java.lang.Object.class, new HODefaultTableCellRenderer());
+        setDefaultRenderer(Object.class, new HODefaultTableCellRenderer());
         RefreshManager.instance().registerRefreshable(this);
     }
 

--- a/src/main/java/tool/arenasizer/ArenaPanel.java
+++ b/src/main/java/tool/arenasizer/ArenaPanel.java
@@ -45,7 +45,7 @@ final class ArenaPanel extends JPanel {
     ArenaPanel() {
     	setLayout(new BorderLayout());
     	add(new JScrollPane(m_jtArena));
-        m_jtArena.setDefaultRenderer(java.lang.Object.class, new HODefaultTableCellRenderer());
+        m_jtArena.setDefaultRenderer(Object.class, new HODefaultTableCellRenderer());
         m_jtArena.getTableHeader().setReorderingAllowed(false);
         initTabelle();
         reInit();

--- a/src/main/java/tool/arenasizer/DistributionStatisticsPanel.java
+++ b/src/main/java/tool/arenasizer/DistributionStatisticsPanel.java
@@ -42,7 +42,7 @@ class DistributionStatisticsPanel extends JPanel {
 	protected JScrollPane createTable() {
 		JTable table = new JTable(getModel());
 		//table.setDefaultRenderer(Object.class, new UpdaterCellRenderer());
-		table.setDefaultRenderer(java.lang.Object.class, new HODefaultTableCellRenderer());
+		table.setDefaultRenderer(Object.class, new HODefaultTableCellRenderer());
 		table.getTableHeader().setReorderingAllowed(false);
 
 		final TableColumnModel columnModel = table.getColumnModel();

--- a/src/main/java/tool/arenasizer/Stadium.java
+++ b/src/main/java/tool/arenasizer/Stadium.java
@@ -241,7 +241,7 @@ public class Stadium extends AbstractTable.Storable {
      *
      * @param m_sStadienname New value of property m_sStadienname.
      */
-    public final void setStadienname(java.lang.String m_sStadienname) {
+    public final void setStadienname(String m_sStadienname) {
         this.m_sStadienname = m_sStadienname;
     }
 
@@ -250,7 +250,7 @@ public class Stadium extends AbstractTable.Storable {
      *
      * @return Value of property m_sStadienname.
      */
-    public final java.lang.String getStadienname() {
+    public final String getStadienname() {
         return m_sStadienname;
     }
 


### PR DESCRIPTION
1. changes proposed in this pull request:
- Removed the superfluous qualification of `java.lang.String` and `java.lang.Object` because they are imported implicitly.

2. `src/main/resources/release_notes.md` ...
 - [x] does not require update

3. [Optional] suggested person to review this PR @wsbrenk
