### PR TITLE
refactor: Standardize utility classes

### DIFF
--- a/src/main/java/core/gui/theme/FontUtil.java
+++ b/src/main/java/core/gui/theme/FontUtil.java
@@ -6,6 +6,7 @@ import java.awt.GraphicsEnvironment;
 public class FontUtil {
 	
 	private FontUtil() {
+		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
 	}
 	
     private static String checkInstalledFont(String targetFont, String sample, Font[] allfonts) {

--- a/src/main/java/core/gui/theme/ImageUtilities.java
+++ b/src/main/java/core/gui/theme/ImageUtilities.java
@@ -27,6 +27,10 @@ import javax.swing.*;
 
 public class ImageUtilities {
 
+	private ImageUtilities() {
+		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+	}
+
     /** Hashtable mit Veränderungspfeilgrafiken nach Integer als Key */
     private static final Hashtable<Integer,ImageIcon> m_clPfeilCache = new Hashtable<>();
     private static final Hashtable<Integer,ImageIcon> m_clPfeilWideCache = new Hashtable<>();

--- a/src/main/java/core/util/CurrencyUtils.java
+++ b/src/main/java/core/util/CurrencyUtils.java
@@ -11,7 +11,9 @@ public class CurrencyUtils {
 
 	public static String CURRENCYSYMBOL = "";
 
-	private CurrencyUtils() {}
+	private CurrencyUtils() {
+		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+	}
 
 	/**
 	 * convert currency value in swedish krone to local currency

--- a/src/main/java/core/util/DateTimeUtils.java
+++ b/src/main/java/core/util/DateTimeUtils.java
@@ -22,10 +22,8 @@ public class DateTimeUtils {
 
 	private static Map<String, String> cl_availableZoneIds;
 
-	/**
-	 * Utility class - private constructor enforces non-instantiability.
-	 */
 	private DateTimeUtils() {
+		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
 	}
 
 	public static Map<String, String> getAvailableZoneIds() {

--- a/src/main/java/core/util/ExceptionUtils.java
+++ b/src/main/java/core/util/ExceptionUtils.java
@@ -10,11 +10,8 @@ import java.io.Writer;
  */
 public class ExceptionUtils {
 
-	/**
-	 * Utility class - private constructor enforces noninstantiability.
-	 */
 	private ExceptionUtils() {
-		// do nothing
+		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
 	}
 
 	/**

--- a/src/main/java/core/util/GUIUtils.java
+++ b/src/main/java/core/util/GUIUtils.java
@@ -16,6 +16,7 @@ import javax.swing.KeyStroke;
 public class GUIUtils {
 
 	private GUIUtils() {
+		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
 	}
 
 	/**

--- a/src/main/java/core/util/Helper.java
+++ b/src/main/java/core/util/Helper.java
@@ -22,6 +22,10 @@ import java.util.Vector;
  */
 public class Helper {
 
+	private Helper() {
+		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+	}
+
 	/**
 	 * Form selections
 	 */

--- a/src/main/java/core/util/IOUtils.java
+++ b/src/main/java/core/util/IOUtils.java
@@ -18,10 +18,8 @@ import java.io.Writer;
  */
 public class IOUtils {
 
-	/**
-	 * Utility class - private constructor enforces noninstantiability.
-	 */
 	private IOUtils() {
+		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
 	}
 
 	/**

--- a/src/main/java/core/util/MathUtils.java
+++ b/src/main/java/core/util/MathUtils.java
@@ -2,6 +2,10 @@ package core.util;
 
 public class MathUtils {
 
+    private MathUtils() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
     static void checkNonNegative(String role, double x) {
         if (!(x >= 0)) {
             throw new IllegalArgumentException(role + " (" + x + ") must be >= 0");

--- a/src/main/java/core/util/OSUtils.java
+++ b/src/main/java/core/util/OSUtils.java
@@ -4,6 +4,11 @@ package core.util;
  * Provides OS-specific utility functions.
  */
 public final class OSUtils {
+
+    private OSUtils() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
     public static final String OS_NAME = System.getProperty("os.name").toLowerCase();
     public enum OS {WINDOWS, LINUX, MAC}
     private static OS os = determineOS();

--- a/src/main/java/core/util/StringUtils.java
+++ b/src/main/java/core/util/StringUtils.java
@@ -9,10 +9,8 @@ import core.model.TranslationFacility;
  */
 public class StringUtils {
 
-	/**
-	 * Utility class - private constructor enforces noninstantiability.
-	 */
 	private StringUtils() {
+		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
 	}
 
 	/**

--- a/src/main/java/core/util/XMLUtils.java
+++ b/src/main/java/core/util/XMLUtils.java
@@ -17,10 +17,8 @@ import org.xml.sax.SAXException;
 
 public class XMLUtils {
 
-	/**
-	 * Utility class - private constructor enforces noninstantiability.
-	 */
 	private XMLUtils() {
+		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
 	}
 
 	/**

--- a/src/main/java/module/ifa/PluginIfaUtils.java
+++ b/src/main/java/module/ifa/PluginIfaUtils.java
@@ -27,6 +27,10 @@ import org.w3c.dom.Element;
 
 public class PluginIfaUtils {
 
+	private PluginIfaUtils() {
+		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+	}
+
 	private static String getTeamDetails(int teamID) throws Exception {
 		return MyConnector.instance().getTeamDetails(teamID);
 	}

--- a/src/main/java/module/nthrf/NthrfUtil.java
+++ b/src/main/java/module/nthrf/NthrfUtil.java
@@ -17,6 +17,10 @@ import java.util.List;
 
 public class NthrfUtil {
 
+    private NthrfUtil() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
     /**
      * TODO
      * @return success of the operation

--- a/src/main/java/module/teamAnalyzer/ui/RatingUtil.java
+++ b/src/main/java/module/teamAnalyzer/ui/RatingUtil.java
@@ -14,10 +14,9 @@ import java.util.StringTokenizer;
  * @author <a href=mailto:draghetto@users.sourceforge.net>Massimiliano Amato</a>
  */
 public final class RatingUtil {
-    /**
-     * Private default constructor to prevent class instantiation.
-     */
+
     private RatingUtil() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }
 
     /**


### PR DESCRIPTION
1. changes proposed in this pull request:
Standardizing means that the utility class has a private constructor that throws UnsupportedOperationException to make clear that there is never the intension to have an instance of that class.

2. `src/main/resources/release_notes.md` ...
 - [x] does not require update

3. [Optional] suggested person to review this PR @tychobrailleur 
