### PR TITLE
refactor: Remove confusing final modifier

### DIFF
--- a/src/main/java/module/matches/SpielerSternePanel.java
+++ b/src/main/java/module/matches/SpielerSternePanel.java
@@ -98,7 +98,7 @@ final class SpielerSternePanel extends ImagePanel implements ActionListener {
 	/**
 	 * Erzeugt die Komponenten
 	 */
-	private final void initComponents() {
+	private void initComponents() {
 		final GridBagLayout layout = new GridBagLayout();
 		final GridBagConstraints constraints = new GridBagConstraints();
 		constraints.fill = GridBagConstraints.BOTH;


### PR DESCRIPTION
1. changes proposed in this pull request:
Since final classes cannot be inherited, marking a method as final may be unnecessary and confusing.

2. `src/main/resources/release_notes.md` ...
 - [x] does not require update

3. [Optional] suggested person to review this PR @wsbrenk 
