### PR TITLE
refactor: Use constant StandardCharsets.UTF_8 and StandardCharsets.UTF_16 instead of literal

### DIFF
--- a/src/main/java/core/gui/language/LanguageTableModel.java
+++ b/src/main/java/core/gui/language/LanguageTableModel.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -164,7 +165,7 @@ public class LanguageTableModel extends AbstractTableModel implements TableModel
 		BufferedWriter bw = null;
 
 		try {
-			bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(destinationPath.getPath()), "UTF-8"));
+			bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(destinationPath.getPath()), StandardCharsets.UTF_8));
 
 			// Loop over table and put into properties
             for (String key : this.keys) {

--- a/src/main/java/core/net/test/ConnTest.java
+++ b/src/main/java/core/net/test/ConnTest.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import javax.swing.JTextArea;
@@ -79,7 +80,7 @@ public class ConnTest {
 			httpurlconnection.setRequestMethod("GET");
 			httpurlconnection.connect();
 			InputStream is = httpurlconnection.getInputStream();
-			final BufferedReader br = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+			final BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
 			StringBuilder sb = new StringBuilder();
 			String line = null;
 			boolean found = false;
@@ -119,7 +120,7 @@ public class ConnTest {
 			httpurlconnection.setRequestMethod("GET");
 			httpurlconnection.connect();
 			InputStream is = httpurlconnection.getInputStream();
-			final BufferedReader br = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+			final BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
 			String line = null;
 			boolean found = false;
 			while ((line = br.readLine()) != null) {

--- a/src/main/java/core/util/UTF8Control.java
+++ b/src/main/java/core/util/UTF8Control.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
@@ -41,7 +42,7 @@ public class UTF8Control extends Control {
         if (stream != null) {
             try {
                 // Only this line is changed to make it to read properties files as UTF-8.
-                bundle = new PropertyResourceBundle(new InputStreamReader(stream, "UTF-8"));
+                bundle = new PropertyResourceBundle(new InputStreamReader(stream, StandardCharsets.UTF_8));
             } finally {
                 stream.close();
             }

--- a/src/main/java/core/util/UnicodeConverter.java
+++ b/src/main/java/core/util/UnicodeConverter.java
@@ -7,6 +7,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Simple converter to convert an language file for the use in HO. Input must be
@@ -31,7 +32,7 @@ public class UnicodeConverter {
 				System.out.println("Can't access input file '" + input + "'!");
 				return;
 			}
-			r = new BufferedReader(new InputStreamReader(new FileInputStream(input), "UTF-16"));
+			r = new BufferedReader(new InputStreamReader(new FileInputStream(input), StandardCharsets.UTF_16));
 			String line;
 			int linecount = 0;
 			while ((line = r.readLine()) != null) {


### PR DESCRIPTION
1. changes proposed in this pull request:
Use constant StandardCharsets.UTF_8 and StandardCharsets.UTF_16 instead of literal.

2. `src/main/resources/release_notes.md` ...
- [x] does not require update

3. [Optional] suggested person to review this PR @wsbrenk 