### PR TITLE
fix: Use UTF-8 encoding for German umlauts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -71,3 +71,7 @@ tab_width = 4
 indent_style = space
 indent_size = 4
 tab_width = 4
+
+# Property files for translations
+[*.properties]
+charset = utf-8

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+.idea/*
+# explicitly included for default encoding of property file in UTF-8
+!.idea/encodings.xml
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml
@@ -144,7 +148,6 @@ local.properties
 .DS_Store
 /updateDB.py
 /.idea/jarRepositories.xml
-.idea/
 /database.data
 /database.properties
 /database.script

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" defaultCharsetForPropertiesFiles="UTF-8" />
+</project>

--- a/src/main/resources/language/German.properties
+++ b/src/main/resources/language/German.properties
@@ -2261,7 +2261,7 @@ ls.player.ratingend = Bewertung am Ende des Spiels
 ls.player.lastminutes = Einsatzdauer
 ls.player.lastlineup = Position letzter Einsatz
 ls.player.motherclub.name = Heimatverein
-ls.player.matchescurrentteam = Spiele für aktuellen Verein
+ls.player.matchescurrentteam = Spiele fÃ¼r aktuellen Verein
 ls.about.database.folder = Datenbank-Verzeichnis
 ls.about.logs.folder = Logging-Verzeichnis
 # ArenaInfoPanel


### PR DESCRIPTION
1. changes proposed in this pull request:
Fixed a German umlaut form latin-1 to UTF-8 in the translation file for German.
Additionally the file `encodings.xml` from IDEA is stored in the repository prevent using the wrong encoding again accidentally in the future.

2. `src/main/resources/release_notes.md` ...
- [ ] has been updated
- [x] does not require update

