### PR TITLE
fix: Prevent class cast exception by using AmountOfMoney instead of BigDecimal

### DIFF
--- a/src/main/java/module/playeranalysis/skillcompare/PlayerTableModel.java
+++ b/src/main/java/module/playeranalysis/skillcompare/PlayerTableModel.java
@@ -194,7 +194,7 @@ public class PlayerTableModel extends DefaultTableModel{
             data[counter][35] = tmpPlayer.getPositionCompareAsString(IMatchRoleID.FORWARD);
             data[counter][36] = tmpPlayer.getPositionCompareAsString(IMatchRoleID.FORWARD_DEF);
             data[counter][37] = tmpPlayer.getPositionCompareAsString(IMatchRoleID.FORWARD_TOWING);
-            data[counter][38] = tmpPlayer.getWages().toLocale();
+            data[counter][38] = tmpPlayer.getWages();
             data[counter][39] = tmpPlayer.getTSI();
             data[counter][40] = tmpPlayer.getId();
             counter++;


### PR DESCRIPTION
1. changes proposed in this pull request:
There was a class cast exception when scrolling in the `Player Analysis` / `Player Comparison` table to the right (on potential visibility of the `Wage` column).

2. `src/main/resources/release_notes.md` ...
- [x] does not require update

