### PR TITLE
fix: Show translation of column 'Tactic' and 'Details'. Show tactics itself.

### DIFF
--- a/src/main/java/module/specialevents/SpecialEventsTableModel.java
+++ b/src/main/java/module/specialevents/SpecialEventsTableModel.java
@@ -9,11 +9,12 @@ import core.gui.theme.HOIconName;
 import core.gui.theme.ThemeManager;
 import core.model.HOVerwaltung;
 import core.model.match.IMatchDetails;
+import core.model.match.Matchdetails;
 import core.util.HODateTime;
 
+import javax.swing.*;
 import java.util.ArrayList;
 import java.util.List;
-import javax.swing.*;
 
 public class SpecialEventsTableModel extends HOTableModel {
 
@@ -40,7 +41,7 @@ public class SpecialEventsTableModel extends HOTableModel {
 					@Override
 					public IHOTableCellEntry getTableEntry(MatchRow entry) {
 						var tacticId = entry.getMatch().getHostingTeamTactic();
-						var ret = new ColorLabelEntry(tacticId, "", ColorLabelEntry.FG_STANDARD, ColorLabelEntry.BG_STANDARD, SwingConstants.LEFT);
+						var ret = new ColorLabelEntry(tacticId, Matchdetails.getShortTacticName(tacticId), ColorLabelEntry.FG_STANDARD, ColorLabelEntry.BG_STANDARD, SwingConstants.LEFT);
 						ret.setIcon(getTacticIcon(tacticId));
 						return ret;
 					}
@@ -63,11 +64,11 @@ public class SpecialEventsTableModel extends HOTableModel {
 						return  new ColorLabelEntry(entry.getMatch().getVisitingTeam(), ColorLabelEntry.FG_STANDARD, ColorLabelEntry.BG_STANDARD, SwingConstants.LEFT);
 					}
 				},
-				new SpecialEventsColumn("ls.team.guest.tactic") {
+				new SpecialEventsColumn("ls.team.tactic") {
 					@Override
 					public IHOTableCellEntry getTableEntry(MatchRow entry) {
 						var tacticId = entry.getMatch().getVisitingTeamTactic();
-						var ret = new ColorLabelEntry(tacticId, "", ColorLabelEntry.FG_STANDARD, ColorLabelEntry.BG_STANDARD, SwingConstants.LEFT);
+						var ret = new ColorLabelEntry(tacticId, Matchdetails.getShortTacticName(tacticId), ColorLabelEntry.FG_STANDARD, ColorLabelEntry.BG_STANDARD, SwingConstants.LEFT);
 						ret.setIcon(getTacticIcon(tacticId));
 						return ret;
 					}

--- a/src/main/resources/language/English.properties
+++ b/src/main/resources/language/English.properties
@@ -441,6 +441,7 @@ ls.team.tactic.attackinthemiddle=Attack in the Middle
 ls.team.tactic.attackonwings=Attack on wings
 ls.team.tactic.playcreatively=Play creatively
 ls.team.tactic.longshots=Long shots
+ls.match.event.details=Details
 
 #Values for Match tactics (shortened)
 ls.team.tactic_short.normal=NO
@@ -1529,7 +1530,7 @@ bestOfWeek=Best of the Week
 worstOfWeek=Worst of the Week
 bestOfSeason=Best of the Season
 worstOfSeason=Worst of the Season
-        
+
 #HRF-Explorer
 Tab_HRF-Explorer=HRF-Explorer
 jan=January

--- a/src/main/resources/language/German.properties
+++ b/src/main/resources/language/German.properties
@@ -1110,6 +1110,7 @@ WEATHER_TECHNICAL_SUNNY = Ballzauberer in der Sonne
 WEITSCHUSS_TOR = Weitschuss
 ls.match.event.counter-attack = Konter
 ls.match.event.longshot = Weitschuss
+ls.match.event.details=Details
 # filters
 specialEvents.filter.matchTypes.title = Spielarten
 specialEvents.filter.matchTypes.friendly = Freundschaftsspiele

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -38,6 +38,11 @@
 
 ### Youth module
 
+### Special Events
+
+* Fixed the missing translation for the home/away `Tactic` and `Details` column and displaying the abbreviation of the
+  tactic now in the corresponding column.
+
 ### Option setting
 * Add option to select currency setting (#2288)
 


### PR DESCRIPTION
1. changes proposed in this pull request:
Show translation of column 'Tactic' and 'Details'. Show tactics itself.

2. `src/main/resources/release_notes.md` ...
- [x] has been updated
