### PR TITLE
fix: Correct average wage calculation of team summary

### DIFF
--- a/src/main/java/core/util/MathUtils.java
+++ b/src/main/java/core/util/MathUtils.java
@@ -1,5 +1,11 @@
 package core.util;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 public class MathUtils {
 
     private MathUtils() {
@@ -20,4 +26,13 @@ public class MathUtils {
      || (a == b) // needed to ensure that infinities equal themselves
       || (Double.isNaN(a) && Double.isNaN(b));
        }
+
+    public static Optional<BigDecimal> average(List<BigDecimal> bigDecimals, RoundingMode roundingMode, int scale) {
+        if (bigDecimals.isEmpty()) {
+            return Optional.empty();
+        }
+
+        BigDecimal sum = bigDecimals.stream().map(Objects::requireNonNull).reduce(BigDecimal.ZERO, BigDecimal::add);
+        return Optional.of(sum.divide(BigDecimal.valueOf(bigDecimals.size()), scale, roundingMode));
+    }
 }

--- a/src/main/java/module/playeroverview/TeamSummaryModel.java
+++ b/src/main/java/module/playeroverview/TeamSummaryModel.java
@@ -2,11 +2,20 @@ package module.playeroverview;
 
 import core.model.player.Player;
 import core.util.AmountOfMoney;
+import core.util.MathUtils;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
+import java.math.RoundingMode;
 import java.util.List;
 
+@Setter
 public class TeamSummaryModel {
 
+    @ToString
+    @EqualsAndHashCode
     static class TeamStatistics {
         int numPlayers;
         double averageAge;
@@ -17,20 +26,9 @@ public class TeamSummaryModel {
         double averageForm;
     }
 
+    @Getter
     private List<Player> players;
     private List<Player> comparisonPlayers;
-
-    public List<Player> getPlayers() {
-        return players;
-    }
-
-    public void setPlayers(List<Player> players) {
-        this.players = players;
-    }
-
-    public void setComparisonPlayers(List<Player> comparisonPlayers) {
-        this.comparisonPlayers = comparisonPlayers;
-    }
 
     TeamStatistics getTeamStatistics() {
         return computeTeamStatistics(this.players);
@@ -42,7 +40,6 @@ public class TeamSummaryModel {
      * @return TeamStatistics – bean containing the delta for each stat.
      */
     TeamStatistics getComparisonTeamStatistics() {
-
         TeamStatistics deltaStats = new TeamStatistics();
 
         if (this.comparisonPlayers != null) {
@@ -61,15 +58,17 @@ public class TeamSummaryModel {
         return deltaStats;
     }
 
-    private TeamStatistics computeTeamStatistics(List<Player> players) {
+    static TeamStatistics computeTeamStatistics(List<Player> players) {
         TeamStatistics stats = new TeamStatistics();
 
         stats.numPlayers = players.size();
         stats.totalTsi = players.stream().mapToLong(Player::getTsi).sum();
         stats.averageTsi = players.stream().mapToDouble(Player::getTsi).average().orElse(0.0);
         stats.averageAge = players.stream().mapToDouble(Player::getAlterWithAgeDays).average().orElse(0.0);
-        var average = players.stream().mapToDouble(p->p.getWage().toLocale().doubleValue()).average().orElse(0);
-        stats.averageSalary = new AmountOfMoney((long)average) ;
+        var average = MathUtils.average(players.stream()
+            .map(Player::getWage)
+            .map(AmountOfMoney::getSwedishKrona).toList(), RoundingMode.HALF_UP, 2);
+        stats.averageSalary = average.map(AmountOfMoney::new).orElse(new AmountOfMoney(0));
         stats.averageStamina = players.stream().mapToDouble(Player::getStamina).average().orElse(0.0);
         stats.averageForm = players.stream().mapToDouble(Player::getForm).average().orElse(0.0);
 

--- a/src/test/java/core/util/MathUtilsTest.java
+++ b/src/test/java/core/util/MathUtilsTest.java
@@ -1,0 +1,52 @@
+package core.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MathUtilsTest {
+
+    private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
+    private static final int SCALE = 2;
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void average_withNullForList_throws_NPE() {
+        assertThatThrownBy(() -> MathUtils.average(null, ROUNDING_MODE, SCALE))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void average_withListIncludingNull_throws_NPE() {
+        final List<BigDecimal> bigDecimals = new ArrayList<>();
+        bigDecimals.add(BigDecimal.TEN);
+        bigDecimals.add(null);
+
+        assertThatThrownBy(() -> MathUtils.average(bigDecimals, ROUNDING_MODE, SCALE))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void average_withEmptyList_return_optionalEmpty() {
+        assertThat(MathUtils.average(List.of(), ROUNDING_MODE, SCALE)).isNotPresent();
+    }
+
+    @Test
+    void average() {
+        // given
+        final var bigDecimals = List.of(BigDecimal.valueOf(12.255), BigDecimal.valueOf(13.355), BigDecimal.valueOf(14.455));
+
+        // when
+        final var average = MathUtils.average(bigDecimals, ROUNDING_MODE, SCALE);
+
+        // then
+        assertThat(average).isEqualTo(Optional.of(BigDecimal.valueOf(13.36)));
+    }
+}

--- a/src/test/java/module/playeroverview/TeamSummaryModelTest.java
+++ b/src/test/java/module/playeroverview/TeamSummaryModelTest.java
@@ -1,0 +1,62 @@
+package module.playeroverview;
+
+import core.model.HOModel;
+import core.model.HOVerwaltung;
+import core.model.misc.Basics;
+import core.model.player.Player;
+import core.util.AmountOfMoney;
+import core.util.HODateTime;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TeamSummaryModelTest {
+
+    @Test
+    void computeTeamStatistics() {
+        // given
+        HOVerwaltung.instance().setModel(createHOModel());
+        final var players = List.of(createPlayer(1), createPlayer(2));
+        final var expectedTeamStatistics = new TeamSummaryModel.TeamStatistics();
+        expectedTeamStatistics.numPlayers = 2;
+        expectedTeamStatistics.averageAge = 19.63392857142857;
+        expectedTeamStatistics.averageSalary = new AmountOfMoney(BigDecimal.valueOf(150000).setScale(2, RoundingMode.HALF_UP));
+        expectedTeamStatistics.totalTsi = 3000;
+        expectedTeamStatistics.averageTsi = 1500;
+        expectedTeamStatistics.averageStamina = 1.5;
+        expectedTeamStatistics.averageForm = 1.5;
+
+        // when
+        final var teamStatistics = TeamSummaryModel.computeTeamStatistics(players);
+
+        // then
+        assertThat(teamStatistics).isEqualTo(expectedTeamStatistics);
+    }
+
+    private static Player createPlayer(int n) {
+        Player player = new Player();
+        player.setTsi(1000 * n);
+        player.setAge(18 + n);
+        player.setAgeDays(10 * n);
+        player.setWage(new AmountOfMoney(100000L * n));
+        player.setStamina(n);
+        player.setForm(n);
+        return player;
+    }
+
+    private static HOModel createHOModel() {
+        HOModel hoModel = new HOModel(HODateTime.now());
+        hoModel.setBasics(createBasis());
+        return hoModel;
+    }
+
+    private static Basics createBasis() {
+        Basics basics = new Basics();
+        basics.setDatum(HODateTime.now());
+        return basics;
+    }
+}


### PR DESCRIPTION
1. changes proposed in this pull request:
The average wage of the team is not correct displayed when using the currency Euro with a factor 10 lower than Swedish krona.
Fixes a bug that was introduced with #2288.

2. `src/main/resources/release_notes.md` ...
- [x] does not require update

