### PR TITLE
Fix unit tests.

### DIFF
--- a/src/main/java/core/util/AmountOfMoney.kt
+++ b/src/main/java/core/util/AmountOfMoney.kt
@@ -6,7 +6,6 @@ import core.model.WorldDetailsManager
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.NumberFormat
-import java.util.*
 
 /**
  * Amounts of money are stored in swedish krona and displayed in players' locale
@@ -65,13 +64,13 @@ data class AmountOfMoney(var swedishKrona: BigDecimal) {
          */
         fun parse(v: String?): AmountOfMoney? {
             var amount: Number?
-            try {
-                amount = currencyFormatter?.parse(v)
+            amount = try {
+                currencyFormatter?.parse(v)
             } catch (_: Exception) {
                 try {
-                    amount = Helper.getNumberFormat(0).parse(v)
+                    Helper.getNumberFormat(0).parse(v)
                 } catch (ex: Exception) {
-                    HOLogger.instance().error(Helper::class.java, "error parsing currency " + ex)
+                    HOLogger.instance().error(Helper::class.java, "error parsing currency $ex")
                     return null
                 }
             }
@@ -121,6 +120,15 @@ data class AmountOfMoney(var swedishKrona: BigDecimal) {
                 if (exchangeRate == null) return BigDecimal(1)
             }
             return exchangeRate!!
+        }
+
+        /**
+         * sets the exchange rate explicitly.
+         *
+         * @param exchangeRate Exchange Rate to be set.
+         */
+        fun setExchangeRate(exchangeRate: BigDecimal) {
+            this.exchangeRate = exchangeRate
         }
 
         /**
@@ -190,9 +198,9 @@ data class AmountOfMoney(var swedishKrona: BigDecimal) {
      */
     @JvmOverloads
     fun toLocaleString( decimals : Int = 0): String {
-        val formatter =  getCurrencyFormatter()
-        formatter.maximumFractionDigits=decimals
-        formatter.minimumFractionDigits=decimals
+        val formatter = getCurrencyFormatter()
+        formatter.maximumFractionDigits = decimals
+        formatter.minimumFractionDigits = decimals
         return formatter.format(this.toLocale())
     }
 

--- a/src/test/java/core/db/backup/BackupHelperTest.kt
+++ b/src/test/java/core/db/backup/BackupHelperTest.kt
@@ -28,7 +28,6 @@ internal class BackupHelperTest {
 
 	private fun zipFileName() = "db_user-${formatter.format(LocalDate.now())}.zip"
 
-
 	private fun listFilesInZip(zipPath: String): List<String> {
 		return ZipFile(zipPath)
 			.entries()
@@ -77,7 +76,7 @@ internal class BackupHelperTest {
 		(1..5).forEach { i ->
 			val date = currentDate.minusDays(i.toLong())
 			val f = File(testResourcesDir, "db/db_user-${formatter.format(date)}.zip")
-			f.createNewFile()
+			Assertions.assertDoesNotThrow { f.createNewFile() }
 			Files.setLastModifiedTime(f.toPath(), FileTime.from(date.toInstant(ZoneOffset.UTC)))
 		}
 

--- a/src/test/java/core/util/HOCurrencyTests.kt
+++ b/src/test/java/core/util/HOCurrencyTests.kt
@@ -4,11 +4,21 @@ import core.model.HOModel
 import core.model.HOVerwaltung
 import core.model.UserParameter
 import core.model.XtraData
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
+import java.util.Locale
 
 class HOCurrencyTests {
+    var currentLocale: Locale = Locale.getDefault()
+
+    @BeforeEach
+    fun setup() {
+        Locale.setDefault(Locale.GERMANY)
+    }
+
     @Test
     fun test() {
         // Prepare model
@@ -19,6 +29,7 @@ class HOCurrencyTests {
         UserParameter.instance().currencyRate = 10f
 
         val amountOfMoney = AmountOfMoney(10)
+        AmountOfMoney.setExchangeRate(BigDecimal.valueOf(10))
         Assertions.assertEquals(BigDecimal.valueOf(1), amountOfMoney.toLocale())
 
         val e = AmountOfMoney(50)
@@ -27,5 +38,10 @@ class HOCurrencyTests {
         val d = AmountOfMoney(amountOfMoney.swedishKrona + BigDecimal.valueOf(90))
         val nbsp = "\u00A0"
         Assertions.assertEquals("10" + nbsp + "€", d.toLocaleString())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Locale.setDefault(currentLocale)
     }
 }

--- a/src/test/resources/db/.keep.data
+++ b/src/test/resources/db/.keep.data
@@ -1,0 +1,1 @@
+DO NOT DELETE.

--- a/src/test/resources/db/.keep.properties
+++ b/src/test/resources/db/.keep.properties
@@ -1,0 +1,1 @@
+DO NOT DELETE

--- a/src/test/resources/db/.keep.script
+++ b/src/test/resources/db/.keep.script
@@ -1,0 +1,1 @@
+DO NOT DELETE.


### PR DESCRIPTION
- Restore the db folder in test/resources that was causing `BackupHelperTest` to fail; also ensure the backup folder is created without exception
- `HOCurrencyTest` was pulling the full application including `HOMainFrame`, to retrieve current exchange rate.  This change now allows the exchange rate to be overridden.  It also explicitly sets the locale to Germany, as the test was failing for my own Locale (en_IE), which formats currency as €10.

1. changes proposed in this pull request:

Cf. above.


2. `src/main/resources/release_notes.md` ...

 - [ ] has been updated
 - [x] does not require update

