### PR TITLE
Run unit tests as part of the build pipeline.

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -23,6 +23,8 @@ jobs:
           distribution: 'temurin'
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v5
+      - name: Run unit tests
+        run: ./gradlew test
       - name: Download and install install4j
         run: wget https://download.ej-technologies.com/install4j/install4j_linux-x64_12_0_2.deb && sudo dpkg -i install4j_linux-x64_12_0_2.deb
       - name: Build with Gradle


### PR DESCRIPTION
1. changes proposed in this pull request:

This runs the unit tests as part of the build pipeline, as [discussed](https://github.com/ho-dev/HattrickOrganizer/pull/2398#pullrequestreview-3684610419).  This works fine locally, and fails the build when unit tests fail.  This only triggers on release and master branches, but we could create a GH action workflow that triggers and runs validations for all branches, if needs be.


2. `src/main/resources/release_notes.md` ...

 - [ ] has been updated
 - [x] does not require update

