### PR TITLE
Fix empty list of upcoming matches in Lineup on first run.

### DIFF
--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -24,6 +24,8 @@
 
 ### Lineup
 
+* Fix empty list of upcoming games in Lineup panel after first download.
+
 ### Training
 * Add experience skill to training tables (#2283)
 


### PR DESCRIPTION
On first run, when no database is initialised, the list of upcoming matches remains empty in the lineup tab after the first download, until the next restart of HO.  This is due to the ID of the current team not being initialised yet, and not reset after the actual download.

This fix retrieves the value of the current team ID from the model, similar to what is done in the Team Analyser tab.

1. changes proposed in this pull request:

Cf. above

2. `src/main/resources/release_notes.md` ...

 - [x] has been updated
 - [ ] does not require update

