### PR TITLE
fix: Handle special events that result from games without special event.

### DIFF
--- a/src/main/java/module/specialevents/MatchRow.java
+++ b/src/main/java/module/specialevents/MatchRow.java
@@ -1,43 +1,21 @@
 package module.specialevents;
 
 import core.model.match.MatchEvent;
+import lombok.Getter;
+import lombok.Setter;
 
+import java.util.Optional;
+
+@Getter
+@Setter
 public class MatchRow {
 
-	private Match match;
-	private MatchEvent matchHighlight;
-	private boolean isMatchHeaderLine;
-	private int matchCount;	
+    private Match match;
+    private MatchEvent matchHighlight;
+    private boolean matchHeaderLine;
+    private int matchCount;
 
-	public Match getMatch() {
-		return match;
-	}
-
-	public void setMatch(Match match) {
-		this.match = match;
-	}
-
-	public boolean isMatchHeaderLine() {
-		return isMatchHeaderLine;
-	}
-
-	public void setMatchHeaderLine(boolean isMatchHeaderLine) {
-		this.isMatchHeaderLine = isMatchHeaderLine;
-	}
-
-	public MatchEvent getMatchHighlight() {
-		return matchHighlight;
-	}
-
-	public void setMatchHighlight(MatchEvent matchHighlight) {
-		this.matchHighlight = matchHighlight;
-	}
-
-	public int getMatchCount() {
-		return matchCount;
-	}
-
-	public void setMatchCount(int matchCount) {
-		this.matchCount = matchCount;
-	}
+    public Optional<MatchEvent> getMatchHighlight() {
+        return Optional.ofNullable(matchHighlight);
+    }
 }

--- a/src/main/resources/release_notes.md
+++ b/src/main/resources/release_notes.md
@@ -46,6 +46,10 @@
 ### Option setting
 * Add option to select currency setting (#2288)
 
+### Special Events
+
+* Fixed a crash that occurred when not ticking `Only matches with SEs`.
+
 ### Misc
 
 * Fix CVEs with HO dependencies


### PR DESCRIPTION
1. changes proposed in this pull request:
Events in the special events table crashed when not ticking `Only matches with SEs`.
Games that result from a walkover with an opponent with less than 9 players do not have special events but result in an entry. This entry caused an NPE.

2. `src/main/resources/release_notes.md` ...
- [x] has been updated