### PR TITLE
fix: Squad: Prevent NPE after changing 'Override' after download

### DIFF
--- a/src/main/java/core/model/player/Player.java
+++ b/src/main/java/core/model/player/Player.java
@@ -1207,7 +1207,7 @@ public class Player extends AbstractTable.Storable {
      * @param flag boolean
      */
     public void setCanBeSelectedByAssistant(boolean flag) {
-        if (flag == canBeSelectedByAssistant) {
+        if (Boolean.valueOf(flag).equals(canBeSelectedByAssistant)) {
             return; // Nothing changed
         }
         if (this.isExternallyRecruitedCoach()) {


### PR DESCRIPTION
1. changes proposed in this pull request:
There occurs and NPE when you are in the `Squad` make a fresh download and then changing the `Override` of a player.

2. `src/main/resources/release_notes.md` ...
- [x] does not require update

