### PR TITLE
feat: Add continue-on-error to delete tag step

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -45,6 +45,7 @@ jobs:
         id: show_version
         run: cat version.properties
       - name: Delete previous tag and release
+        continue-on-error: true
         uses: tychobrailleur/delete-tag-and-release@453626e2f16a2625a19e18d91e4cdf1f41624dde
         with:
           delete_release: true


### PR DESCRIPTION
1. changes proposed in this pull request:
Make it possible to continue run release-dev action even if the previous delete of the release does not exist anymore.

2. `src/main/resources/release_notes.md` ...
- [x] does not require update

