### PR TITLE
chore(deps): Update assertj-core to 3.27.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation "org.codehaus.groovy:groovy-all:3.0.24"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     testImplementation "org.junit.jupiter:junit-jupiter:5.14.2"
-    testImplementation "org.assertj:assertj-core:3.26.3"
+    testImplementation "org.assertj:assertj-core:3.27.7"
     testImplementation "org.jetbrains.kotlin:kotlin-test:2.1.20"
 }
 


### PR DESCRIPTION
1. changes proposed in this pull request:
Update assertj-core to 3.27.7 due to CVE-2026-24400.

2. `src/main/resources/release_notes.md` ...
- [x] does not require update

